### PR TITLE
Fixes new response from CMS admin.

### DIFF
--- a/djangocms_text_ckeditor/static/ckeditor_plugins/cmsplugins/plugin.js
+++ b/djangocms_text_ckeditor/static/ckeditor_plugins/cmsplugins/plugin.js
@@ -174,10 +174,11 @@ jQuery(document).ready(function ($) {
 					parent_id: that.page_id,
 					plugin_type: item.attr('rel')
 				},
-				'success': function (plugin_id) {
-					if(plugin_id === 'error') return false;
-
-					that.addPluginDialog(item, plugin_id);
+				'success': function (data) {
+					if(data === 'error') return false;
+                    // TODO: this is ugly fix -- find a better way:
+                    var plugin_id = data.url.split('/').reverse()[1];
+                    that.addPluginDialog(item, plugin_id);
 				},
 				'error': function () {
 					alert('There was an error creating the plugin.');


### PR DESCRIPTION
New response contains data object, e.g.:

``` js
{'url': u'/admin/cms/page/edit-plugin/351/', 'breadcrumb': [{'url': u'/admin/cms/page/edit-plugin/81/', 'title': u'Text'}, {'url': u'/admin/cms/page/edit-plugin/351/', 'title': u'L\xe4nk'}]}
```

Related to #33
