### PR TITLE
The return of AbstractText class

### DIFF
--- a/djangocms_text_ckeditor/models.py
+++ b/djangocms_text_ckeditor/models.py
@@ -7,11 +7,14 @@ from djangocms_text_ckeditor.utils import plugin_tags_to_id_list, replace_plugin
 from djangocms_text_ckeditor.html import clean_html, extract_images
 
 
-class Text(CMSPlugin):
+class AbstractText(CMSPlugin):
     """Abstract Text Plugin Class"""
     body = models.TextField(_("body"))
 
     search_fields = ('body',)
+
+    class Meta:
+        abstract = True
 
     def __unicode__(self):
         return u"%s" % (truncate_words(strip_tags(self.body), 3)[:30] + "...")
@@ -21,7 +24,7 @@ class Text(CMSPlugin):
         body = extract_images(body, self)
         body = clean_html(body, full=False)
         self.body = body
-        super(Text, self).save(*args, **kwargs)
+        super(AbstractText, self).save(*args, **kwargs)
 
     def clean_plugins(self):
         ids = plugin_tags_to_id_list(self.body)
@@ -40,3 +43,7 @@ class Text(CMSPlugin):
         self.body = replace_plugin_tags(old_instance.get_plugin_instance()[0].body, replace_ids)
         self.save()
 
+class Text(AbstractText):
+
+    class Meta:
+        abstract = False


### PR DESCRIPTION
All of the plugin behaviors is defined in the AbstractText class, like in the old text plugin.

This makes easy to extend the text editor plugin. 

See #26
