### PR TITLE
Fix for empty placeholder_id

### DIFF
--- a/djangocms_text_ckeditor/templates/cms/plugins/widgets/ckeditor.html
+++ b/djangocms_text_ckeditor/templates/cms/plugins/widgets/ckeditor.html
@@ -19,7 +19,7 @@ $(document).ready(function () {
 		CMS.CKEditor.init(container, {{ settings|safe }}, {
 			'static_url': '{{ STATIC_URL }}',
 			'add_plugin_url': '{{ placeholder.get_add_url }}',
-			'placeholder_id': {{ placeholder.pk }},
+            'placeholder_id': {{ placeholder.pk|default:"''" }},
 			'plugin_id': {{ plugin_pk }},
 			'plugin_language': '{{ plugin.language }}',
 			'lang': {


### PR DESCRIPTION
Assign default empty value to placeholder_id, in effect when HTMLField is used in plain models

Fixes #46
