### PR TITLE
Optionally disable the Drag And Drop image feature.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,8 @@ There is a setting called:
 you can overwrite this setting in your settings.py and point it to a function that handles image saves.
 Have a look at the function `create_picture_plugin` for details.
 
+To completely disable the feature, set `TEXT_SAVE_IMAGE_FUNCTION = None`.
+
 
 Translations
 ------------

--- a/djangocms_text_ckeditor/html.py
+++ b/djangocms_text_ckeditor/html.py
@@ -35,6 +35,8 @@ def extract_images(data, plugin):
     extracts base64 encoded images from drag and drop actions in browser and saves
     those images as plugins
     """
+    if not TEXT_SAVE_IMAGE_FUNCTION:
+        return data
     tree_builder = html5lib.treebuilders.getTreeBuilder('dom')
     parser = html5lib.html5parser.HTMLParser(tree = tree_builder)
     dom = parser.parse(data)


### PR DESCRIPTION
This enables me to bypass the parsing and encoding cycle of html5lib that was mangling my markup.
