### PR TITLE
Django 1.6 fixes

### DIFF
--- a/djangocms_text_ckeditor/templates/cms/plugins/widgets/ckeditor.html
+++ b/djangocms_text_ckeditor/templates/cms/plugins/widgets/ckeditor.html
@@ -53,11 +53,9 @@ $(document).ready(function () {
 
 	// if the elements are not visible, reload
 	// TODO this is an open issue on ckeditor: http://dev.ckeditor.com/ticket/9802
-	if($.browser.mozilla) {
-		setTimeout(function () {
-			if($('.cke_button_icon:visible').length === 0) window.location.reload();
-		}, 200);
-	}
+	setTimeout(function () {
+		if($('.cke_button_icon:visible').length === 0) window.location.reload();
+	}, 200);
 });
 })(CMS.$);
 </script>


### PR DESCRIPTION
JQuery 1.9 now bundled in django-admin.

JQuery 1.9 no longer has $.browser, and I'm able to reproduce bug in Chromium.
