### PR TITLE
Make migration dependant on `cms`.

### DIFF
--- a/djangocms_text_ckeditor/migrations/0001_initial.py
+++ b/djangocms_text_ckeditor/migrations/0001_initial.py
@@ -8,7 +8,7 @@ from django.db import models
 class Migration(SchemaMigration):
 
     depends_on = (
-        ('cms', '0012_publisher.py'),
+        ('cms', '0001_initial.py'),
     )
 
     def forwards(self, orm):


### PR DESCRIPTION
Fixes migration errors when running tests when `djangocms_text_ckeditor` is listed _before_ `cms` in `INSTALLED_APPS` (as advised in the docs).

```
Creating test database for alias 'default'...
FATAL ERROR - The following SQL query failed: ALTER TABLE "cmsplugin_text" ADD CONSTRAINT "cmsplugin_ptr_id_refs_id_34ad5108" FOREIGN KEY ("cmsplugin_ptr_id") REFERENCES "cms_cmsplugin" ("id") DEFERRABLE INITIALLY DEFERRED;
The error was: relation "cms_cmsplugin" does not exist

Error in migration: djangocms_text_ckeditor:0001_initial
DatabaseError: relation "cms_cmsplugin" does not exist
```
