### PR TITLE
Handle blank mime_type's in inline image data

### DIFF
--- a/djangocms_text_ckeditor/html.py
+++ b/djangocms_text_ckeditor/html.py
@@ -61,7 +61,11 @@ def extract_images(data, plugin):
             image_data = base64.b64decode(image_data)
         except:
             image_data = base64.urlsafe_b64decode(image_data)
-        image_type = mime_type.split("/")[1]
+        try:
+            image_type = mime_type.split("/")[1]
+        except IndexError:
+            # No image type specified -- will convert to jpg below if it's valid image data
+            image_type = ""
         image = StringIO(image_data)
         # genarate filename and normalize image format
         if image_type == "jpg" or image_type == "jpeg":


### PR DESCRIPTION
Addresses issue #79.  Fall back to an attempt to open the given image data with PIL and convert to JPEG if no image type is specified in the mime_type for Base64 inline images.
