### PR TITLE
Handle auto-maximizing ckeditor directly in plugin

### DIFF
--- a/djangocms_text_ckeditor/static/js/cms.ckeditor.js
+++ b/djangocms_text_ckeditor/static/js/cms.ckeditor.js
@@ -54,7 +54,7 @@ $(document).ready(function () {
 		// setup is called after ckeditor has been initialized
 		setup: function () {
 			// auto maximize modal if alone in a modal
-			if (this._is_alone_in_a_modal()) {
+			if (this._isAloneInModal()) {
 				this.editor.execCommand('maximize');
 			}
 
@@ -69,7 +69,7 @@ $(document).ready(function () {
 				.css('float', 'right');
 		},
 
-		_is_alone_in_a_modal: function () {
+		_isAloneInModal: function () {
 			// return true if the ckeditor is alone in a modal popup
 			return this.container.parents('body.djangocms_text_ckeditor-text').length > 0;
 		}


### PR DESCRIPTION
Two fixes come with this pull-request:
- we haven't to rely on a timeout to auto-maximize ckeditor (how long to wait ?)
- when editing a custom model with a ckeditor in the middle of other fields, the ckeditor is no longer maximized when modal is maximized.

And less cke specific code in django cms modal js…

Tested on firefox 25.

It is related to issue #87.
