### PR TITLE
Make migration dependant on `cms`.

### DIFF
--- a/djangocms_text_ckeditor/migrations/0001_initial.py
+++ b/djangocms_text_ckeditor/migrations/0001_initial.py
@@ -7,6 +7,10 @@ from django.db import models
 
 class Migration(SchemaMigration):
 
+    depends_on = (
+        ('cms', '0001_initial.py'),
+    )
+
     def forwards(self, orm):
         # Adding model 'Text'
         db.create_table('cmsplugin_text', (


### PR DESCRIPTION
Backports to 1.x of #84
