### PR TITLE
Fixed the 'Edit Plugin' context menu option from breaking

### DIFF
--- a/djangocms_text_ckeditor/static/ckeditor_plugins/cmsplugins/plugin.js
+++ b/djangocms_text_ckeditor/static/ckeditor_plugins/cmsplugins/plugin.js
@@ -137,7 +137,7 @@ $(document).ready(function () {
 			this.editor.removeMenuItem('image');
 
 			this.editor.contextMenu.addListener(function(element) {
-				if (element.getAttribute('id').indexOf('plugin_obj_') === 0) {
+				if (element.$.id.indexOf('plugin_obj_') === 0) {
 					return { cmspluginsItem: CKEDITOR.TRISTATE_OFF };
 				}
 			});


### PR DESCRIPTION
For some reason, CKEditor won't display a context menu when asked, instead giving the following error:

plugin.js:140 - Uncaught TypeError: Cannot call method 'indexOf' of null

It seems the code tries to decide whether or not the currently selected element is indeed a CMSPlugin by checking it's id for the string 'plugin_obj', and if it isn't, it hides the context menu item.

Only for whatever reason, element.getAttribute('id') for me returns 'null'. An alternative method element.$.id seems to work fine.

This is on Chromium and Firefox on Ubuntu 13.10, using the latest version of everything.
