### PR TITLE
Update INSTALL_REQUIRES in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,9 @@ from djangocms_text_ckeditor import __version__
 
 
 INSTALL_REQUIRES = [
+    'django-cms>=2.3',
     'html5lib',
+    'Pillow',
 ]
 
 CLASSIFIERS = [


### PR DESCRIPTION
Since `PIL` is imported in `html.py`, it should be pulled in during installation time in order to avoid import errors. `PIL` (specifically it's newer incarnation `Pillow`) is optional for `django-cms` but here it looks like it's mandatory. It's also nice to check for Django CMS during installation time because `djangocms-text-ckeditor` is a Django CMS plugin.
