### PR TITLE
Set window.CKEDITOR_BASEPATH in text_plugin_change_form.html to fix #124 properly

### DIFF
--- a/djangocms_text_ckeditor/cms_plugins.py
+++ b/djangocms_text_ckeditor/cms_plugins.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.forms.fields import CharField
 from django.utils.translation import ugettext_lazy as _
 
@@ -54,6 +55,11 @@ class TextPlugin(CMSPluginBase):
         We override the change form template path
         to provide backwards compatibility with CMS 2.x
         """
+        ckeditor_basepath = '{0}/ckeditor/'.format(settings.STATIC_URL)
+        if ckeditor_basepath.startswith('//'):
+            protocol = 'https' if request.is_secure else 'http'
+            ckeditor_basepath = '{0}:{1}'.format(protocol, ckeditor_basepath)
+        context.update({'CKEDITOR_BASEPATH': ckeditor_basepath})
         if cms_version.startswith('2'):
             context['change_form_template'] = "admin/cms/page/plugin_change_form.html"
         return super(TextPlugin, self).render_change_form(request, context, add, change, form_url, obj)

--- a/djangocms_text_ckeditor/templates/cms/plugins/text_plugin_change_form.html
+++ b/djangocms_text_ckeditor/templates/cms/plugins/text_plugin_change_form.html
@@ -3,7 +3,7 @@
 
 {% block extrahead %}
 {{ block.super }}
-<script>window.CKEDITOR_BASEPATH = "{{ STATIC_URL }}ckeditor/";</script>
+<script>window.CKEDITOR_BASEPATH = "{{ CKEDITOR_BASEPATH }}";</script>
 <script src="{% static "cms/js/modules/cms.base.js" %}"></script>
 <script>
 (function($) {


### PR DESCRIPTION
The [previous pull request](https://github.com/divio/djangocms-text-ckeditor/pull/125) did not work if settings.STATIC_URL was a protocol-independent URL, e.g. //static.example.com/files.

This fixes 124 properly by adding the protocol to these URLs.
