### PR TITLE
Optionally disable HTML sanitizing.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -181,6 +181,8 @@ you may customize the tags and attributes allowed by overriding the
     TEXT_ADDITIONAL_TAGS = ('iframe',)
     TEXT_ADDITIONAL_TAGS = ('scrolling', 'allowfullscreen', 'frameborder')
 
+To completely disable the feature, set ``TEXT_HTML_SANITIZE = False``.
+
 See the `html5lib documentation`_ for further information.
 
 .. _html5lib: https://pypi.python.org/pypi/html5lib

--- a/djangocms_text_ckeditor/html.py
+++ b/djangocms_text_ckeditor/html.py
@@ -10,24 +10,31 @@ import re
 import base64
 from PIL import Image
 from .settings import (TEXT_SAVE_IMAGE_FUNCTION, TEXT_ADDITIONAL_TAGS,
-                       TEXT_ADDITIONAL_ATTRIBUTES)
+                       TEXT_ADDITIONAL_ATTRIBUTES, TEXT_HTML_SANITIZE)
 from djangocms_text_ckeditor.utils import plugin_to_tag
 
 
 def _get_default_parser():
-    sanitizer.HTMLSanitizer.acceptable_elements.extend(TEXT_ADDITIONAL_TAGS)
-    sanitizer.HTMLSanitizer.acceptable_attributes.extend(TEXT_ADDITIONAL_ATTRIBUTES)
-    sanitizer.HTMLSanitizer.allowed_elements = (
-        sanitizer.HTMLSanitizer.acceptable_elements +
-        sanitizer.HTMLSanitizer.mathml_elements +
-        sanitizer.HTMLSanitizer.svg_elements)
-    sanitizer.HTMLSanitizer.allowed_attributes = (
-        sanitizer.HTMLSanitizer.acceptable_attributes +
-        sanitizer.HTMLSanitizer.mathml_attributes +
-        sanitizer.HTMLSanitizer.svg_attributes)
+    opts = {}
 
-    return html5lib.HTMLParser(tokenizer=sanitizer.HTMLSanitizer,
-                               tree=treebuilders.getTreeBuilder("dom"))
+    if TEXT_HTML_SANITIZE:
+        sanitizer.HTMLSanitizer.acceptable_elements.extend(
+            TEXT_ADDITIONAL_TAGS)
+        sanitizer.HTMLSanitizer.acceptable_attributes.extend(
+            TEXT_ADDITIONAL_ATTRIBUTES)
+        sanitizer.HTMLSanitizer.allowed_elements = (
+            sanitizer.HTMLSanitizer.acceptable_elements +
+            sanitizer.HTMLSanitizer.mathml_elements +
+            sanitizer.HTMLSanitizer.svg_elements)
+        sanitizer.HTMLSanitizer.allowed_attributes = (
+            sanitizer.HTMLSanitizer.acceptable_attributes +
+            sanitizer.HTMLSanitizer.mathml_attributes +
+            sanitizer.HTMLSanitizer.svg_attributes)
+        opts['tokenizer'] = sanitizer
+
+    return html5lib.HTMLParser(tree=treebuilders.getTreeBuilder("dom"),
+                               **opts)
+
 DEFAULT_PARSER = _get_default_parser()
 
 

--- a/djangocms_text_ckeditor/settings.py
+++ b/djangocms_text_ckeditor/settings.py
@@ -21,3 +21,4 @@ else:
 TEXT_SAVE_IMAGE_FUNCTION = getattr(settings, 'TEXT_SAVE_IMAGE_FUNCTION', save_function_default)
 TEXT_ADDITIONAL_TAGS = getattr(settings, 'TEXT_ADDITIONAL_TAGS', ())
 TEXT_ADDITIONAL_ATTRIBUTES = getattr(settings, 'TEXT_ADDITIONAL_ATTRIBUTES', ())
+TEXT_HTML_SANITIZE = getattr(settings, 'TEXT_HTML_SANITIZE', True)


### PR DESCRIPTION
Replaces #126

needed to insert this kind of stuff:

```
<a href="https://itunes.apple.com/us/app/depop/id518684914?mt=8&uo=4" target="itunes_store" style="display:inline-block;overflow:hidden;background:url(https://linkmaker.itunes.apple.com/htmlResources/assets/en_us//images/web/linkmaker/badge_appstore-lrg.png) no-repeat;width:135px;height:40px;@media only screen{background-image:url(https://linkmaker.itunes.apple.com/htmlResources/assets/en_us//images/web/linkmaker/badge_appstore-lrg.svg);}"></a>
```
