### PR TITLE
[fix] seperate toolbar in placeholder field and html field

### DIFF
--- a/djangocms_text_ckeditor/settings.py
+++ b/djangocms_text_ckeditor/settings.py
@@ -5,6 +5,7 @@ from django.conf import settings
 CKEDITOR_SETTINGS = getattr(settings, 'CKEDITOR_SETTINGS', {
     'language': '{{ language }}',
     'toolbar': 'CMS',
+    'toolbar_htmlfield': 'HTMLField',
     'skin': 'moono',
 #    'stylesSet': [
 #        {'name': 'Custom Style', 'element': 'h3', 'styles': {'color': 'Blue'}}

--- a/djangocms_text_ckeditor/widgets.py
+++ b/djangocms_text_ckeditor/widgets.py
@@ -37,11 +37,14 @@ class TextEditorWidget(Textarea):
 
     def render_additions(self, name, value, attrs=None):
         language = get_language().split('-')[0]
+        ck_settings = text_settings.CKEDITOR_SETTINGS
+        if not self.placeholder and 'toolbar_htmlfield' in ck_settings:
+            ck_settings['toolbar'] = ck_settings['toolbar_htmlfield']
         context = {
             'ckeditor_class': self.ckeditor_class,
             'name': name,
             'language': language,
-            'settings': language.join(json.dumps(text_settings.CKEDITOR_SETTINGS).split("{{ language }}")),
+            'settings': language.join(json.dumps(ck_settings).split("{{ language }}")),
             'STATIC_URL': settings.STATIC_URL,
             'installed_plugins': self.installed_plugins,
             'plugin_pk': self.pk,


### PR DESCRIPTION
When using a custom toolbar (by overwriting `CKEDITOR_SETTINGS['toolbar']`) you cannot use a different toolbar for the placeholder plugin and the `HTMLField` widget (despite being prepared [here](https://github.com/divio/djangocms-text-ckeditor/blob/master/djangocms_text_ckeditor/static/js/cms.ckeditor.js#L30-L43) and implemented [here](https://github.com/divio/djangocms-text-ckeditor/blob/master/djangocms_text_ckeditor/templates/cms/plugins/widgets/ckeditor.html#L44-L45) (which will never be considered since `toolbar` from `settings` will always be used first.)

This fixes this, using `CKEDITOR_SETTINGS['toolbar_htmlfield']` instead of `CKEDITOR_SETTINGS['toolbar']` when it's not a placeholder and the setting is available.
