### PR TITLE
django.utils.six supports urllib since 1.5 - we need to do imports the old way

### DIFF
--- a/djangocms_text_ckeditor/cms_plugins.py
+++ b/djangocms_text_ckeditor/cms_plugins.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from django.forms.fields import CharField
-from django.utils.six.moves.urllib.parse import urljoin
 from django.utils.translation import ugettext_lazy as _
 
 from cms import __version__ as cms_version
@@ -12,6 +11,11 @@ from .widgets import TextEditorWidget
 from .models import Text
 from .utils import plugin_tags_to_user_html
 from .forms import TextForm
+
+try:
+    from urlparse import urljoin
+except ImportError:
+    from urllib.parse import urljoin
 
 
 class TextPlugin(CMSPluginBase):


### PR DESCRIPTION
This is a temporary fix for bug introduced in #144. We need to wait until django 1.5 is minimum required version by django CMS because `urllib` moves are not supported in django 1.4.
