### PR TITLE
Integrate test suite with tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist
 djangocms_text_ckeditor.egg-info
 *.DS_Store
 .idea
+.tox

--- a/schemamigration.py
+++ b/schemamigration.py
@@ -1,38 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import sys
-
-INSTALLED_APPS = [
-    'django.contrib.contenttypes',
-    'django.contrib.auth',
-    'django.contrib.sessions',
-    'django.contrib.sites',
-    'django.contrib.admin',
-    'mptt',
-    'cms',
-    'menus',
-    'djangocms_text_ckeditor',
-    'south',
-]
-
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': ':memory:',
-    }
-}
-
-TEMPLATE_CONTEXT_PROCESSORS = [
-    'django.core.context_processors.auth',
-    'django.core.context_processors.i18n',
-    'django.core.context_processors.request',
-    'django.core.context_processors.media',
-    'django.core.context_processors.static',
-    'cms.context_processors.media',
-    'sekizai.context_processors.sekizai',
-]
-
-ROOT_URLCONF = 'cms.urls'
+import test_settings
 
 
 def schemamigration():
@@ -43,11 +12,10 @@ def schemamigration():
 
     from django.core.management import ManagementUtility
     settings.configure(
-        INSTALLED_APPS=INSTALLED_APPS,
-        ROOT_URLCONF=ROOT_URLCONF,
-        DATABASES=DATABASES,
-        TEMPLATE_CONTEXT_PROCESSORS=TEMPLATE_CONTEXT_PROCESSORS
-    )
+        INSTALLED_APPS=test_settings.INSTALLED_APPS,
+        DATABASES=test_settings.DATABASES,
+        TEMPLATE_CONTEXT_PROCESSORS=test_settings.TEMPLATE_CONTEXT_PROCESSORS,
+        ROOT_URLCONF=test_settings.ROOT_URLCONF)
     argv = list(sys.argv)
     argv.insert(1, 'schemamigration')
     argv.insert(2, 'djangocms_text_ckeditor')

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,0 +1,35 @@
+INSTALLED_APPS = [
+    'django.contrib.contenttypes',
+    'django.contrib.auth',
+    'django.contrib.sessions',
+    'django.contrib.sites',
+    'django.contrib.admin',
+    'mptt',
+    'cms',
+    'menus',
+    'djangocms_text_ckeditor',
+    'south',
+]
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
+    }
+}
+
+TEMPLATE_CONTEXT_PROCESSORS = [
+    'django.core.context_processors.auth',
+    'django.core.context_processors.i18n',
+    'django.core.context_processors.request',
+    'django.core.context_processors.media',
+    'django.core.context_processors.static',
+    'cms.context_processors.media',
+    'sekizai.context_processors.sekizai',
+]
+
+ROOT_URLCONF = 'cms.urls'
+
+SECRET_KEY = 'p*gkh#3zd6rpt*l%^4+4=2+*l$er!-uzef2ol3rmgu^m=-#f1w'
+
+SOUTH_TESTS_MIGRATE = False

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist =
+    py27-dj16-cms30,
+
+[testenv]
+downloadcache = {toxworkdir}/_download/
+commands =
+    {envbindir}/django-admin.py test --settings=test_settings djangocms_text_ckeditor
+setenv =
+    PYTHONPATH = {toxinidir}
+
+[testenv:py27-dj16-cms30]
+basepython = python2.7
+deps =
+    Django==1.6.5
+    Django-CMS==3.0.3


### PR DESCRIPTION
This should make running the test suite much easier :) I've moved the settings out of the schemamigration.py script and into a test_settings.py module that can then be used by the script and the test-runner.
