### PR TITLE
Fixes #166

### DIFF
--- a/djangocms_text_ckeditor/static/djangocms_text_ckeditor/ckeditor_plugins/cmsplugins/plugin.js
+++ b/djangocms_text_ckeditor/static/djangocms_text_ckeditor/ckeditor_plugins/cmsplugins/plugin.js
@@ -235,7 +235,7 @@ $(document).ready(function () {
 
 		setupDataProcessor: function () {
 			var link_name = this.options.lang.link;
-			var link_pattern = new RegExp("/^"+ link_name +"\s-\s(.+)$/");
+			var link_pattern = new RegExp("^"+ link_name +"\\s-\\s(.+)$");
 
 			this.editor.dataProcessor.dataFilter.addRules({
 				elements: {


### PR DESCRIPTION
This regression has been introduced by @yakky in 3a93332053cfed

Again, I would like to emphasize the importance of #143. If this would have been fixed, this bug here probably never would have occurred, but if we continue to abuse this hacky img tag for storing plugin information in markup text, then similar errors will occur in the future.
