### PR TITLE
Limit available plugins in the editor

### DIFF
--- a/djangocms_text_ckeditor/cms_plugins.py
+++ b/djangocms_text_ckeditor/cms_plugins.py
@@ -52,7 +52,7 @@ class TextPlugin(CMSPluginBase):
 
     def get_form(self, request, obj=None, **kwargs):
         plugins = plugin_pool.get_text_enabled_plugins(
-            self.placeholder,
+            self.placeholder.slot,
             self.page
         )
         pk = self.cms_plugin_instance.pk


### PR DESCRIPTION
If I have this setting : 

``` python
CMS_PLACEHOLDER_CONF = {
    'home_abstract': {
        'plugins': ['TextPlugin',],
        'text_only_plugins': ['LinkPlugin',],
    },
}
```

And I have many other text compatible plugins (eg : FilerFilePlugin and FilerImagePlugin), we have all text compatible plugins in the CKEditor plugins dropdown and not only plugins listed in `text_only_plugins`.
This is because `plugin_pool.get_text_enabled_plugins` and `plugin_pool.get_all_plugins` require a slot name and not a placeholder instance to retrieve the placeholder configuration. As it can not find the conf, the available plugins list return ALL plugins.
