### PR TITLE
Changed __unicode__ to __str__ for PY3

### DIFF
--- a/djangocms_text_ckeditor/models.py
+++ b/djangocms_text_ckeditor/models.py
@@ -12,11 +12,13 @@ from django.utils.text import Truncator
 from django.utils.translation import ugettext_lazy as _
 
 from cms.models import CMSPlugin
+from cms.utils.compat.dj import python_2_unicode_compatible
 
 from .utils import plugin_tags_to_id_list, replace_plugin_tags, plugin_to_tag
 from .html import clean_html, extract_images
 
 
+@python_2_unicode_compatible
 class AbstractText(CMSPlugin):
     """Abstract Text Plugin Class"""
     body = models.TextField(_("body"))
@@ -27,7 +29,7 @@ class AbstractText(CMSPlugin):
     class Meta:
         abstract = True
 
-    def __unicode__(self):
+    def __str__(self):
         return Truncator(strip_tags(self.body)).words(3, truncate="...")
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
`get_short_description` calls `force_unicode` which on Python 3.x uses the representation returned by `__str__()`. TextPlugin did not previously define a **str** override so it used the definition from the base CMSPlugin class, which just displays the PK. This meant in structure editing mode, a placeholder would unhelpfully show "Text 22" rather than a bit of truncated text to help distinguish instances.
