### PR TITLE
Fix loading static files with CachedStaticFilesStorage outside CMS

### DIFF
--- a/djangocms_text_ckeditor/cms_plugins.py
+++ b/djangocms_text_ckeditor/cms_plugins.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.forms.fields import CharField
 from django.utils.translation import ugettext_lazy as _
 
@@ -11,11 +10,6 @@ from .widgets import TextEditorWidget
 from .models import Text
 from .utils import plugin_tags_to_user_html
 from .forms import TextForm
-
-try:
-    from urlparse import urljoin
-except ImportError:
-    from urllib.parse import urljoin
 
 
 class TextPlugin(CMSPluginBase):
@@ -66,11 +60,6 @@ class TextPlugin(CMSPluginBase):
         We override the change form template path
         to provide backwards compatibility with CMS 2.x
         """
-        ckeditor_basepath = urljoin(settings.STATIC_URL, 'djangocms_text_ckeditor/ckeditor/')
-        if ckeditor_basepath.startswith('//'):
-            protocol = 'https' if request.is_secure else 'http'
-            ckeditor_basepath = '{0}:{1}'.format(protocol, ckeditor_basepath)
-        context.update({'CKEDITOR_BASEPATH': ckeditor_basepath})
         if cms_version.startswith('2'):
             context['change_form_template'] = "admin/cms/page/plugin_change_form.html"
         return super(TextPlugin, self).render_change_form(request, context, add, change, form_url, obj)

--- a/djangocms_text_ckeditor/settings.py
+++ b/djangocms_text_ckeditor/settings.py
@@ -1,3 +1,9 @@
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    # Python 2
+    from urlparse import urljoin
+
 from django.conf import settings
 
 # See http://docs.cksource.com/ckeditor_api/symbols/CKEDITOR.config.html
@@ -22,3 +28,4 @@ TEXT_ADDITIONAL_ATTRIBUTES = getattr(settings, 'TEXT_ADDITIONAL_ATTRIBUTES', ())
 TEXT_ADDITIONAL_PROTOCOLS = getattr(settings, 'TEXT_ADDITIONAL_PROTOCOLS', ())
 TEXT_CKEDITOR_CONFIGURATION = getattr(settings, 'TEXT_CKEDITOR_CONFIGURATION', None)
 TEXT_HTML_SANITIZE = getattr(settings, 'TEXT_HTML_SANITIZE', True)
+TEXT_CKEDITOR_BASE_PATH = getattr(settings, 'TEXT_CKEDITOR_BASE_PATH', urljoin(settings.STATIC_URL, 'djangocms_text_ckeditor/ckeditor/'))

--- a/djangocms_text_ckeditor/templates/cms/plugins/text_plugin_change_form.html
+++ b/djangocms_text_ckeditor/templates/cms/plugins/text_plugin_change_form.html
@@ -3,7 +3,6 @@
 
 {% block extrahead %}
 {{ block.super }}
-<script>window.CKEDITOR_BASEPATH = "{{ CKEDITOR_BASEPATH }}";</script>
 <script src="{% static "cms/js/modules/cms.base.js" %}"></script>
 <script>
 (function($) {

--- a/djangocms_text_ckeditor/templates/cms/plugins/widgets/ckeditor.html
+++ b/djangocms_text_ckeditor/templates/cms/plugins/widgets/ckeditor.html
@@ -5,6 +5,7 @@
 {% endblock %}
 
 {% block extrahead %}
+<script>window.CKEDITOR_BASEPATH = "{{ CKEDITOR_BASEPATH }}";</script>
 <script src="{% static "cms/js/modules/cms.base.js" %}"></script>
 <script src="{% static "djangocms_text_ckeditor/ckeditor/ckeditor.js" %}"></script>
 <script src="{% static "djangocms_text_ckeditor/js/cms.ckeditor.js" %}"></script>

--- a/djangocms_text_ckeditor/widgets.py
+++ b/djangocms_text_ckeditor/widgets.py
@@ -62,6 +62,7 @@ class TextEditorWidget(Textarea):
             'language': language,
             'settings': language.join(json.dumps(configuration).split("{{ language }}")),
             'STATIC_URL': settings.STATIC_URL,
+            'CKEDITOR_BASEPATH': text_settings.TEXT_CKEDITOR_BASE_PATH,
             'installed_plugins': self.installed_plugins,
             'plugin_pk': self.pk,
             'plugin_language': self.plugin_language,


### PR DESCRIPTION
If HTML field is used outside the plugin then `CKEDITOR_BASEPATH` is not set and if CachedStaticFilesStorage is used then static files can't be loaded.

I moved setting `CKEDITOR_BASEPATH` into the widget not in the plugin. The only difference with previous solution is that I don't set the URL schema (because in the widget there is no access to current `request` instance). I think that this will not be a problem because browsers are made to handle this. If for some reason someone has a problem with that it can set the full URL in project's setting by setting `TEXT_CKEDITOR_BASE_PATH` to the right value.
