### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -287,6 +287,15 @@ you may customize the tags and attributes allowed by overriding the
     TEXT_ADDITIONAL_TAGS = ('iframe',)
     TEXT_ADDITIONAL_TAGS = ('scrolling', 'allowfullscreen', 'frameborder')
 
+**NOTE**: Some versions of CKEditor will pre-sanitize your text before passing it to the web server,
+rendering the above settings useless. To ensure this does not happen, you may need to configure the
+following::
+
+   CKEDITOR_SETTINGS = {
+      'basicEntities': False,
+      'entities': False,
+   }
+
 To completely disable the feature, set ``TEXT_HTML_SANITIZE = False``.
 
 See the `html5lib documentation`_ for further information.


### PR DESCRIPTION
TEXT_ADDITIONAL_TAGS was not enough to make this work for me, when HTML is entered into the editor manually.

The editor sanitizes tags before it gets to the server, so the tags in question are treated as text-only.

This is how I fixed it.
