### PR TITLE
Bugfixes/collapsed admin fieldset doesn't initialize CKEditor

### DIFF
--- a/djangocms_text_ckeditor/templates/cms/plugins/widgets/ckeditor.html
+++ b/djangocms_text_ckeditor/templates/cms/plugins/widgets/ckeditor.html
@@ -64,15 +64,15 @@ $(document).ready(function () {
 			add_buttons.data('isInitCMSCKEditor', 'yes');
 		}
 	}
-    //initialize ckeditor when a collapsed row is extended
-    $("fieldset.collapse a.collapse-toggle").click(function(e) {
-        var $this = $(this);
-        if (!$this.closest("fieldset").hasClass("collapsed") && $this.data('isInitCMSCKEditor') != 'yes') {
-            // Show
-            initCMSCKEditor();
-            $this.data('isInitCMSCKEditor', 'yes');
-        }
-    });
+	//initialize ckeditor when a collapsed row is extended
+	$("fieldset.collapse a.collapse-toggle").click(function(e) {
+		var $this = $(this);
+		if (!$this.closest("fieldset").hasClass("collapsed") && $this.data('isInitCMSCKEditor') != 'yes') {
+			// Show
+			initCMSCKEditor();
+			$this.data('isInitCMSCKEditor', 'yes');
+		}
+	});
 });
 })(CMS.$);
 </script>


### PR DESCRIPTION
In admin, when a row is collapsed, the jQuery selector `$('.{{ ckeditor_class }}:visible')` does not match textareas inside the fieldset. This commit add an event listener on the collapse-toggle row and initialize the Editor if is has never been initialized.
