### PR TITLE
correction of the init of ckeditors in collapsed fieldsets in admin

### DIFF
--- a/djangocms_text_ckeditor/templates/cms/plugins/widgets/ckeditor.html
+++ b/djangocms_text_ckeditor/templates/cms/plugins/widgets/ckeditor.html
@@ -65,12 +65,12 @@ $(document).ready(function () {
 		}
 	}
 	//initialize ckeditor when a collapsed row is extended
-	$("fieldset.collapse a.collapse-toggle").click(function(e) {
+	$("#{{ ckeditor_selector }}").closest("fieldset.collapse").find("a.collapse-toggle").click(function(e) {
 		var $this = $(this);
-		if (!$this.closest("fieldset").hasClass("collapsed") && $this.data('isInitCMSCKEditor') != 'yes') {
+		if (!$this.closest("fieldset").hasClass("collapsed") && $this.data('isInitCMSCKEditor_{{ ckeditor_selector }}') != 'yes') {
 			// Show
 			initCMSCKEditor{{ ckeditor_function }}();
-			$this.data('isInitCMSCKEditor', 'yes');
+			$this.data('isInitCMSCKEditor_{{ ckeditor_selector }}', 'yes');
 		}
 	});
 });


### PR DESCRIPTION
Since this commit  c7b978bb5ceea4fe326a872cc5578788d4c9e803 proposed correction for collapsed fieldset and ckeditor init can not work anymore.
Here is an other correction using new individual functions for each text editor.

Related to this file, I saw that `ckeditor_class` has been delete between 2.4.1 and 2.4.2. For everyone who overrided the template and use old code initialisation (with this variable), ckeditors are not initialized anymore. (old selector was :
`$('.{{ ckeditor_class }}:visible')`, so resulting HTML without this variable is : `$('.:visible')` which raises a jQuery error.

I suggest to re-add ckeditor_class to the context used to render the cms/plugins/ckeditor.html template to keep backward compatibility for 2.4.x versions ?
