### PR TITLE
Correction of the too early initCMSCKEditor

### DIFF
--- a/djangocms_text_ckeditor/templates/cms/plugins/widgets/ckeditor.html
+++ b/djangocms_text_ckeditor/templates/cms/plugins/widgets/ckeditor.html
@@ -50,12 +50,9 @@ $(document).ready(function () {
 			});
 		}
 	}
-	function initCMSCKEditor() {
-		initCMSCKEditor{{ ckeditor_function }}();
-	}
 
 	// initialize ckeditor only if the container exists and is ready
-	setTimeout(initCMSCKEditor,50);
+	setTimeout(initCMSCKEditor{{ ckeditor_function }},50);
 
 	// initialize ckeditor in admin inline for "add-row" link
 	var addButtons{{ ckeditor_function }} = $('.add-row a');

--- a/djangocms_text_ckeditor/templates/cms/plugins/widgets/ckeditor.html
+++ b/djangocms_text_ckeditor/templates/cms/plugins/widgets/ckeditor.html
@@ -50,9 +50,12 @@ $(document).ready(function () {
 			});
 		}
 	}
+	function initCMSCKEditor() {
+		initCMSCKEditor{{ ckeditor_function }}();
+	}
 
 	// initialize ckeditor only if the container exists and is ready
-	initCMSCKEditor{{ ckeditor_function }}();
+	setTimeout(initCMSCKEditor,50);
 
 	// initialize ckeditor in admin inline for "add-row" link
 	var addButtons{{ ckeditor_function }} = $('.add-row a');


### PR DESCRIPTION
If you try to save using the django cms pop-up form and forget a required field. During the reloading of the pop-up, if your javascripts are in the body, ckeditor will init before  it is "visible" and won't load.