### PR TITLE
Expand ckeditor if alone in a model popup for Django >= 1.7

### DIFF
--- a/djangocms_text_ckeditor/static/djangocms_text_ckeditor/js/cms.ckeditor.js
+++ b/djangocms_text_ckeditor/static/djangocms_text_ckeditor/js/cms.ckeditor.js
@@ -87,7 +87,8 @@ $(document).ready(function () {
 
 		_isAloneInModal: function () {
 			// return true if the ckeditor is alone in a modal popup
-			return this.container.parents('body.djangocms_text_ckeditor-text').length > 0;
+			return this.container.parents('body.app-djangocms_text_ckeditor.model-text').length > 0 // Django >= 1.7
+				|| this.container.parents('body.djangocms_text_ckeditor-text').length > 0; // Django < 1.7
 		}
 
 	};


### PR DESCRIPTION
Fixes #261: "Inner Frame not expanding to full container size."