### PR TITLE
fake selection on touch devices when editing plugins

### DIFF
--- a/djangocms_text_ckeditor/static/djangocms_text_ckeditor/ckeditor_plugins/cmsplugins/plugin.js
+++ b/djangocms_text_ckeditor/static/djangocms_text_ckeditor/ckeditor_plugins/cmsplugins/plugin.js
@@ -65,7 +65,10 @@ $(document).ready(function () {
 				if (event.type === 'touchend' || event.type === 'click') {
 					var element = event.currentTarget;
 					event.data = event.data ||  {};
+					that.editor.getSelection().fake(new CKEDITOR.dom.element(element));
 				} else {
+					// heavily relies on the fact that double click
+					// also selects an element
 					var selection = that.editor.getSelection();
 					var element = selection.getSelectedElement() || selection.getCommonAncestor().getAscendant('a', true);
 				}


### PR DESCRIPTION
otherwise edited plugin would be inserted again as a first thing in the document, which would create several instances of the same plugin inside of the text editor