### PR TITLE
do not require to focus editor

### DIFF
--- a/djangocms_text_ckeditor/static/djangocms_text_ckeditor/ckeditor_plugins/cmsplugins/plugin.js
+++ b/djangocms_text_ckeditor/static/djangocms_text_ckeditor/ckeditor_plugins/cmsplugins/plugin.js
@@ -26,7 +26,7 @@ $(document).ready(function () {
 				'title': this.options.lang.toolbar,
 				'className' : 'cke_panelbutton__cmsplugins',
 				'modes': { wysiwyg:1 },
-				'editorFocus': 1,
+				'editorFocus': 0,
 
 				'panel': {
 					'css': [CKEDITOR.skin.getPath('editor')].concat(that.editor.config.contentsCss),


### PR DESCRIPTION
otherwise goes into infinite loop of showing/hiding keyboard on some
mobile devices, e.g. nexus 7 (chrome). this also fixes some
inconsistencies on other mobile devices