### PR TITLE
Fixes database error on save().

### DIFF
--- a/djangocms_text_ckeditor/models.py
+++ b/djangocms_text_ckeditor/models.py
@@ -38,9 +38,6 @@ class AbstractText(CMSPlugin):
         self.body = force_text(self.body)
 
     def save(self, *args, **kwargs):
-        # we need to save the plugin first and then save the updated body, otherwise
-        # we cannot set the correct parent on extracted images
-        kwargs['update_fields'] = ('body',)
         super(AbstractText, self).save(*args, **kwargs)
         body = self.body
         body = extract_images(body, self)

--- a/test_settings.py
+++ b/test_settings.py
@@ -36,9 +36,6 @@ HELPER_SETTINGS = {
             'hide_untranslated': False,
         },
     },
-    'MIGRATION_MODULES': {
-        'djangocms_picture': 'djangocms_picture.migrations_django',
-    },
     'CMS_PERMISSION': True,
     'CMS_PLACEHOLDER_CONF': {
         'content': {


### PR DESCRIPTION
``update_fields`` should not be used if the object has not been saved once.

The CMS never actually passed the kwargs to the model's ``save()`` method, this is why this never failed but it did not do anything. A change in the CMS will now pass kwargs to the ``save()`` method and so this breaks because the object needs to be saved first before doing an update.