### PR TITLE
Add space between attributes of plugin_to_tag html

### DIFF
--- a/djangocms_text_ckeditor/utils.py
+++ b/djangocms_text_ckeditor/utils.py
@@ -13,7 +13,7 @@ OBJ_ADMIN_RE = re.compile(OBJ_ADMIN_RE_PATTERN)
 
 def plugin_to_tag(obj):
     return (
-        u'<img src="%(icon_src)s" alt="%(icon_alt)s" title="%(icon_alt)s"'
+        u'<img src="%(icon_src)s" alt="%(icon_alt)s" title="%(icon_alt)s" '
         u'id="plugin_obj_%(id)d" />' % (
             dict(
                 id=obj.id, icon_src=force_escape(obj.get_instance_icon_src()),


### PR DESCRIPTION
While importing older content into `django-cms` I needed to create some plugins and perform some DOM operations.

Unfortunately without proper spaces between attributes `lxml` will fail to create an XML DOM node from the html output of `plugin_to_tag`. I used the HTML parser of lxml and xpath to get a DOM node representing the plugin in the end, but this single space allows the `plugin_to_tag` to be a valid XML node.