### PR TITLE
fix dynamic related_name fails on Django 1.6

### DIFF
--- a/djangocms_text_ckeditor/compat.py
+++ b/djangocms_text_ckeditor/compat.py
@@ -3,5 +3,7 @@ import django
 if django.VERSION < (1, 7):
     from django.utils.module_loading import import_by_path
     import_string = import_by_path
+    LTE_DJANGO_1_6 = True
 else:
     from django.utils.module_loading import import_string  # noqa
+    LTE_DJANGO_1_6 = False  # noqa

--- a/djangocms_text_ckeditor/models.py
+++ b/djangocms_text_ckeditor/models.py
@@ -29,19 +29,23 @@ class AbstractText(CMSPlugin):
     # with any other plugins that have a field with the same name as the
     # lowercase of the class name of this model.
     # https://github.com/divio/django-cms/issues/5030
-    cmsplugin_ptr = models.OneToOneField(
+    if compat.LTE_DJANGO_1_6:
         # related_name='%(app_label)s_%(class)s' does not work on  Django 1.6
-        CMSPlugin,
-        related_name=(
-            'djangocms_text_ckeditor_text' if compat.LTE_DJANGO_1_6
-            else '%(app_label)s_%(class)s'
-        ),
-        parent_link=True,
-    )
+        cmsplugin_ptr = models.OneToOneField(
+            CMSPlugin,
+            related_name='+',
+            parent_link=True,
+        )
+        search_fields = tuple()
+    else:
+        cmsplugin_ptr = models.OneToOneField(
+            CMSPlugin,
+            related_name='%(app_label)s_%(class)s',
+            parent_link=True,
+        )
+        search_fields = ('body',)
 
     body = models.TextField(_("body"))
-
-    search_fields = ('body',)
 
     # This property is deprecated. And will be removed in a future release.
     # It should be set on the Plugin, not the model.

--- a/djangocms_text_ckeditor/models.py
+++ b/djangocms_text_ckeditor/models.py
@@ -10,6 +10,7 @@ from django.utils.text import Truncator
 from django.utils.translation import ugettext_lazy as _
 
 from . import settings
+from . import compat
 from .html import clean_html, extract_images
 from .utils import plugin_tags_to_id_list, plugin_to_tag, replace_plugin_tags
 
@@ -29,7 +30,14 @@ class AbstractText(CMSPlugin):
     # lowercase of the class name of this model.
     # https://github.com/divio/django-cms/issues/5030
     cmsplugin_ptr = models.OneToOneField(
-        CMSPlugin, related_name='%(app_label)s_%(class)s', parent_link=True)
+        # related_name='%(app_label)s_%(class)s' does not work on  Django 1.6
+        CMSPlugin,
+        related_name=(
+            'djangocms_text_ckeditor_text' if compat.LTE_DJANGO_1_6
+            else '%(app_label)s_%(class)s'
+        ),
+        parent_link=True,
+    )
 
     body = models.TextField(_("body"))
 


### PR DESCRIPTION
multi table inheritance related_name does not work on Django 1.6.