### PR TITLE
fixes value error on .create()

### DIFF
--- a/djangocms_text_ckeditor/models.py
+++ b/djangocms_text_ckeditor/models.py
@@ -71,8 +71,11 @@ class AbstractText(CMSPlugin):
             except (TypeError, CMSPlugin.DoesNotExist):
                 body = hyphenate(body)
         self.body = body
-        kwargs['update_fields'] = ('body',)
-        super(AbstractText, self).save(*args, **kwargs)
+        # no need to pass args or kwargs here
+        # this 2nd save() call is internal and should be
+        # fully managed by us.
+        # think of it as an update() vs save()
+        super(AbstractText, self).save(update_fields=('body',))
 
     def clean_plugins(self):
         ids = plugin_tags_to_id_list(self.body)

--- a/djangocms_text_ckeditor/tests/__init__.py
+++ b/djangocms_text_ckeditor/tests/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 from .test_html import *  # NOQA
+from .test_plugin import *  # NOQA
 from .test_sanitizer import *  # NOQA
 from .test_widget import *  # NOQA

--- a/djangocms_text_ckeditor/tests/test_plugin.py
+++ b/djangocms_text_ckeditor/tests/test_plugin.py
@@ -10,7 +10,6 @@ from djangocms_helper.base_test import BaseTestCase
 from djangocms_text_ckeditor.models import Text
 
 
-
 class PluginActionsTestCase(CMSTestCase, BaseTestCase):
 
     def get_page_admin(self):

--- a/djangocms_text_ckeditor/tests/test_plugin.py
+++ b/djangocms_text_ckeditor/tests/test_plugin.py
@@ -1,18 +1,14 @@
 # -*- coding: utf-8 -*-
 import json
 
-from django.contrib import admin
-
 from cms.api import create_page
 from cms.models import CMSPlugin, Page
-from cms.test_utils.testcases import (
-    URL_CMS_PAGE_ADD,
-    URL_CMS_PLUGIN_EDIT,
-    CMSTestCase,
-)
+from cms.test_utils.testcases import CMSTestCase
+from django.contrib import admin
+from djangocms_helper.base_test import BaseTestCase
 
 from djangocms_text_ckeditor.models import Text
-from djangocms_helper.base_test import BaseTestCase
+
 
 
 class PluginActionsTestCase(CMSTestCase, BaseTestCase):

--- a/djangocms_text_ckeditor/tests/test_plugin.py
+++ b/djangocms_text_ckeditor/tests/test_plugin.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+import json
+
+from django.contrib import admin
+
+from cms.api import create_page
+from cms.models import CMSPlugin, Page
+from cms.test_utils.testcases import (
+    URL_CMS_PAGE_ADD,
+    URL_CMS_PLUGIN_EDIT,
+    CMSTestCase,
+)
+
+from djangocms_text_ckeditor.models import Text
+from djangocms_helper.base_test import BaseTestCase
+
+
+class PluginActionsTestCase(CMSTestCase, BaseTestCase):
+
+    def get_page_admin(self):
+        admin.autodiscover()
+        return admin.site._registry[Page]
+
+    def get_post_request(self, data):
+        return self.get_request(post_data=data)
+
+    def get_plugin_id_from_response(self, response, path):
+        # Expects response to be a JSON response
+        # with a structure like so:
+        # {'path.1': {
+        #   'path.2': '/en/admin/app/example1/edit-plugin/3/'}
+        # }
+        # path is used to access nested keys
+
+        data = json.loads(response.content.decode('utf-8'))
+        keys = path.split('.')
+
+        for key in keys:
+            data = data[key]
+        return data.split('/')[-2]
+
+    def test_add_and_edit_plugin(self):
+        """
+        Test that you can add a text plugin
+        """
+        simple_page = create_page('test page', 'page.html', u'en')
+        simple_placeholder = simple_page.placeholders.get(slot='content')
+
+        native_placeholder_admin = self.get_page_admin()
+
+        request = self.get_post_request({
+            'plugin_type': 'TextPlugin',
+            'placeholder_id': simple_placeholder.pk,
+            'plugin_language': 'en',
+            'plugin_parent': '',
+        })
+        response = native_placeholder_admin.add_plugin(request)
+
+        self.assertEqual(response.status_code, 200)
+
+        # Point to the newly created text plugin
+        text_plugin_pk = self.get_plugin_id_from_response(
+            response,
+            path='url',
+        )
+
+        # Assert "ghost" plugin has been created
+        self.assertObjectExist(CMSPlugin.objects.all(), pk=text_plugin_pk)
+
+        # Assert "real" plugin has not been created yet
+        self.assertObjectDoesNotExist(Text.objects.all(), pk=text_plugin_pk)
+
+        request = self.get_post_request({'body': "Hello world"})
+        response = native_placeholder_admin.edit_plugin(request, text_plugin_pk)
+
+        self.assertEqual(response.status_code, 200)
+
+        # Assert "real" plugin has been created yet
+        self.assertObjectExist(Text.objects.all(), pk=text_plugin_pk)
+
+        text_plugin = Text.objects.get(pk=text_plugin_pk)
+
+        # Assert the text was correctly saved
+        self.assertEqual(text_plugin.body, "Hello world")
+
+
+    def test_add_and_cancel_plugin(self):
+        """
+        Test that you can add a text plugin
+        """
+        simple_page = create_page('test page', 'page.html', u'en')
+        simple_placeholder = simple_page.placeholders.get(slot='content')
+
+        native_placeholder_admin = self.get_page_admin()
+
+        request = self.get_post_request({
+            'plugin_type': 'TextPlugin',
+            'placeholder_id': simple_placeholder.pk,
+            'plugin_language': 'en',
+            'plugin_parent': '',
+        })
+        response = native_placeholder_admin.add_plugin(request)
+
+        self.assertEqual(response.status_code, 200)
+
+        # Point to the newly created text plugin
+        text_plugin_pk = self.get_plugin_id_from_response(
+            response,
+            path='url',
+        )
+
+        # Assert "ghost" plugin has been created
+        self.assertObjectExist(CMSPlugin.objects.all(), pk=text_plugin_pk)
+
+        request = self.get_post_request({'body': "Hello world", '_cancel': True})
+        response = native_placeholder_admin.edit_plugin(request, text_plugin_pk)
+
+        self.assertEqual(response.status_code, 200)
+
+        # Assert "ghost" plugin has been removed
+        self.assertObjectDoesNotExist(CMSPlugin.objects.all(), pk=text_plugin_pk)
+
+        # Assert "real" plugin was never created
+        self.assertObjectDoesNotExist(Text.objects.all(), pk=text_plugin_pk)


### PR DESCRIPTION
Calling ```Text.objects.create()``` would throw a ```ValueError``` because ```.create()``` using ```force_insert=True``` and on the second ```save()``` we reuse the kwargs and add update fields which  tells django to update, thus causing a conflict.

This fix is necessary for the sane-add-plugin branch on the CMS.

@yakky @mkoistinen 