### PR TITLE
more adjustments to work with new sane add plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,24 +7,15 @@ sudo: false
 python:
   - 3.5
   - 2.7
-  - 2.6
 
 env:
   matrix:
-  - DJANGO='django16' CMS='cms30'
-  - DJANGO='django16' CMS='cms31'
-  - DJANGO='django16' CMS='cms32'
-  - DJANGO='django17' CMS='cms30'
-  - DJANGO='django17' CMS='cms31'
-  - DJANGO='django17' CMS='cms32'
-  - DJANGO='django18' CMS='cms31'
-  - DJANGO='django18' CMS='cms32'
-  - DJANGO='django19' CMS='cms32'
+  - DJANGO='django18' CMS='cms33'
+  - DJANGO='django19' CMS='cms33'
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
   - pip install -U tox>=1.8 coveralls
-  - "if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then export PYVER=py26; fi"
   - "if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then export PYVER=py27; fi"
   - "if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then export PYVER=py33; fi"
   - "if [[ $TRAVIS_PYTHON_VERSION == '3.4' ]]; then export PYVER=py34; fi"
@@ -34,32 +25,3 @@ install:
 script: COMMAND='coverage run' tox -e"$PYVER-$DJANGO-$CMS",isort,pep8
 
 after_success: coveralls
-
-matrix:
-  exclude:
-    - python: 2.6
-      env: DJANGO='django17' CMS='cms30'
-    - python: 2.6
-      env: DJANGO='django17' CMS='cms31'
-    - python: 2.6
-      env: DJANGO='django17' CMS='cms32'
-    - python: 2.6
-      env: DJANGO='django18' CMS='cms30'
-    - python: 2.6
-      env: DJANGO='django18' CMS='cms31'
-    - python: 2.6
-      env: DJANGO='django18' CMS='cms32'
-    - python: 2.6
-      env: DJANGO='django19' CMS='cms32'
-    - python: 3.5
-      env: DJANGO='django16' CMS='cms30'
-    - python: 3.5
-      env: DJANGO='django16' CMS='cms31'
-    - python: 3.5
-      env: DJANGO='django16' CMS='cms32'
-    - python: 3.5
-      env: DJANGO='django17' CMS='cms30'
-    - python: 3.5
-      env: DJANGO='django17' CMS='cms31'
-    - python: 3.5
-      env: DJANGO='django17' CMS='cms32'

--- a/djangocms_text_ckeditor/cms_plugins.py
+++ b/djangocms_text_ckeditor/cms_plugins.py
@@ -22,6 +22,7 @@ from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext
+from django.views.decorators.clickjacking import xframe_options_sameorigin
 from django.views.decorators.http import require_POST
 
 from . import settings
@@ -84,6 +85,7 @@ class TextPlugin(CMSPluginBase):
 
         return TextPluginForm
 
+    @xframe_options_sameorigin
     def add_view(self, request, form_url='', extra_context=None):
         """
         This is a special case add view for the Text Plugin. Plugins should
@@ -154,6 +156,7 @@ class TextPlugin(CMSPluginBase):
         return url_name
 
     @method_decorator(require_POST)
+    @xframe_options_sameorigin
     @transaction.atomic
     def delete_on_cancel(self, request, plugin_id):
         # This view is responsible for deleting a plugin

--- a/djangocms_text_ckeditor/cms_plugins.py
+++ b/djangocms_text_ckeditor/cms_plugins.py
@@ -195,10 +195,9 @@ class TextPlugin(CMSPluginBase):
             # to avoid non-auth users from triggering validation mechanism.
             plugin._no_reorder = True
 
-            if plugin.parent_id:
+            if plugin.parent and plugin.parent.numchild > 0:
                 CMSPlugin.objects.filter(
                     pk=plugin.parent_id,
-                    numchild__gt=0,
                 ).update(numchild=F('numchild') - 1)
             plugin.delete(no_mp=True)
             # 204 -> request was successful but no response returned.

--- a/djangocms_text_ckeditor/cms_plugins.py
+++ b/djangocms_text_ckeditor/cms_plugins.py
@@ -9,14 +9,14 @@ from django.contrib.admin.utils import unquote
 from django.core import signing
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.core.urlresolvers import reverse
-from django.forms.fields import CharField
 from django.db import transaction
+from django.forms.fields import CharField
 from django.http import (
     Http404,
     HttpResponse,
-    HttpResponseRedirect,
-    HttpResponseForbidden,
     HttpResponseBadRequest,
+    HttpResponseForbidden,
+    HttpResponseRedirect,
 )
 from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator
@@ -197,8 +197,8 @@ class TextPlugin(CMSPluginBase):
 
         placeholder = text_plugin.placeholder
 
-        if not (has_add_permission
-                and placeholder.has_add_permission(request)):
+        if not (has_add_permission and
+                placeholder.has_add_permission(request)):
             message = ugettext("Unable to process your request. "
                                "You don't have the required permissions.")
             return HttpResponseForbidden(message)

--- a/djangocms_text_ckeditor/cms_plugins.py
+++ b/djangocms_text_ckeditor/cms_plugins.py
@@ -195,7 +195,7 @@ class TextPlugin(CMSPluginBase):
             # to avoid non-auth users from triggering validation mechanism.
             plugin._no_reorder = True
 
-            if plugin.parent:
+            if plugin.parent_id:
                 CMSPlugin.objects.filter(
                     pk=plugin.parent_id,
                     numchild__gt=0,

--- a/djangocms_text_ckeditor/cms_plugins.py
+++ b/djangocms_text_ckeditor/cms_plugins.py
@@ -82,26 +82,15 @@ class TextPlugin(CMSPluginBase):
         except ValidationError as error:
             return HttpResponseBadRequest(error.message)
 
-        parent = data.get('plugin_parent')
-
-        if parent:
-            position = parent.cmsplugin_set.count()
-        else:
-            position = CMSPlugin.objects.filter(
-                parent__isnull=True,
-                language=data['plugin_language'],
-                placeholder=data['placeholder_id'],
-            ).count()
-
         plugin = CMSPlugin.objects.create(
             language=data['plugin_language'],
             plugin_type=data['plugin_type'],
-            position=position,
-            placeholder=data['placeholder_id']
+            position=data['position'],
+            placeholder=data['placeholder_id'],
+            parent=data.get('plugin_parent'),
         )
-        return HttpResponseRedirect(
-            admin_reverse('cms_page_edit_plugin', args=(plugin.pk,))
-        )
+        success_url = admin_reverse('cms_page_edit_plugin', args=(plugin.pk,))
+        return HttpResponseRedirect(success_url)
 
     def get_form(self, request, obj=None, **kwargs):
         plugins = get_toolbar_plugin_struct(

--- a/djangocms_text_ckeditor/cms_plugins.py
+++ b/djangocms_text_ckeditor/cms_plugins.py
@@ -224,15 +224,27 @@ class TextPlugin(CMSPluginBase):
             message = ugettext("Unable to process your request. Invalid token.")
             return HttpResponseBadRequest(message)
 
+    @classmethod
+    def get_child_plugin_candidates(cls, slot, page):
+        # This plugin can only have text_enabled plugins
+        # as children.
+        text_enabled_plugins = plugin_pool.get_text_enabled_plugins(
+            placeholder=slot,
+            page=page,
+        )
+        return text_enabled_plugins
+
     def get_form(self, request, obj=None, **kwargs):
+        get_plugin = plugin_pool.get_plugin
+        child_plugin_types = self.get_child_classes(
+            slot=self.placeholder.slot,
+            page=self.page,
+        )
+        child_plugins = (get_plugin(name) for name in child_plugin_types)
         plugins = get_toolbar_plugin_struct(
-            plugin_pool.get_text_enabled_plugins(
-                self.placeholder.slot,
-                self.page
-            ),
+            child_plugins,
             self.placeholder.slot,
             self.page,
-            parent=self.__class__
         )
         form = self.get_form_class(
             request=request,

--- a/djangocms_text_ckeditor/cms_plugins.py
+++ b/djangocms_text_ckeditor/cms_plugins.py
@@ -105,6 +105,15 @@ class TextPlugin(CMSPluginBase):
                 request, form_url, extra_context
             )
 
+        if not self.has_add_permission(request):
+            # this permission check is done by Django on the normal
+            # workflow of adding a plugin.
+            # This is NOT the normal workflow because we create a plugin
+            # on GET request to the /add/ endpoint and so we bypass
+            # django's add_view, thus bypassing permission check.
+            message = ugettext('You do not have permission to add a plugin')
+            return HttpResponseForbidden(force_text(message))
+
         try:
             data = self.validate_add_request(request)
         except PermissionDenied:

--- a/djangocms_text_ckeditor/cms_plugins.py
+++ b/djangocms_text_ckeditor/cms_plugins.py
@@ -188,7 +188,7 @@ class TextPlugin(CMSPluginBase):
             # Token is validated after checking permissions
             # to avoid non-auth users from triggering validation mechanism.
             plugin._no_reorder = True
-            plugin.delete()
+            plugin.delete(no_mp=True)
             # 204 -> request was successful but no response returned.
             return HttpResponse(status=204)
         else:

--- a/djangocms_text_ckeditor/cms_plugins.py
+++ b/djangocms_text_ckeditor/cms_plugins.py
@@ -195,7 +195,7 @@ class TextPlugin(CMSPluginBase):
             # to avoid non-auth users from triggering validation mechanism.
             plugin._no_reorder = True
 
-            if plugin.parent and plugin.parent.numchild > 0:
+            if plugin.parent:
                 CMSPlugin.objects.filter(
                     pk=plugin.parent_id,
                     numchild__gt=0,

--- a/djangocms_text_ckeditor/cms_plugins.py
+++ b/djangocms_text_ckeditor/cms_plugins.py
@@ -187,6 +187,7 @@ class TextPlugin(CMSPluginBase):
         elif form.is_valid_token(request.session.session_key):
             # Token is validated after checking permissions
             # to avoid non-auth users from triggering validation mechanism.
+            plugin._no_reorder = True
             plugin.delete()
             # 204 -> request was successful but no response returned.
             return HttpResponse(status=204)

--- a/djangocms_text_ckeditor/forms.py
+++ b/djangocms_text_ckeditor/forms.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
+from cms.models import CMSPlugin
 from django import forms
 from django.core import signing
 from django.core.signing import BadSignature
 from django.forms.models import ModelForm
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext
-
-from cms.models import CMSPlugin
 
 from .models import Text
 from .utils import plugin_tags_to_id_list

--- a/djangocms_text_ckeditor/forms.py
+++ b/djangocms_text_ckeditor/forms.py
@@ -3,7 +3,6 @@ from django import forms
 from django.core import signing
 from django.db.models import Q
 from django.forms.models import ModelForm
-from django.utils.translation import ugettext
 
 from cms.models import CMSPlugin
 
@@ -40,8 +39,8 @@ class DeleteOnCancelForm(forms.Form):
             .objects
             .select_related('placeholder')
             .filter(
-                Q(plugin_type=self.plugin_type)|
-                Q(parent__plugin_type=self.plugin_type)
+                Q(plugin_type=self.text_plugin_type)|
+                Q(parent__plugin_type=self.text_plugin_type)
             )
         )
         return plugins

--- a/djangocms_text_ckeditor/forms.py
+++ b/djangocms_text_ckeditor/forms.py
@@ -1,8 +1,50 @@
 # -*- coding: utf-8 -*-
 from django import forms
+from django.core import signing
+from django.db.models import Q
 from django.forms.models import ModelForm
+from django.utils.translation import ugettext
+
+from cms.models import CMSPlugin
 
 from .models import Text
+
+
+class DeleteOnCancelForm(forms.Form):
+    plugin = forms.ModelChoiceField(
+        queryset=CMSPlugin.objects.none(),
+        required=True,
+    )
+    token = forms.CharField(required=True)
+
+    def __init__(self, *args, **kwargs):
+        self.text_plugin_type = kwargs.pop('text_plugin_type')
+        super(DeleteOnCancelForm, self).__init__(*args, **kwargs)
+        self.fields['plugin'].queryset = self.get_plugin_queryset()
+
+    def is_valid_token(self):
+        plugin = self.cleaned_data['plugin']
+        payload = ':'.join([plugin.pk, self.cleaned_data['token']])
+        signer = signing.Signer(salt=plugin.plugin_type)
+
+        try:
+            signer.unsign(payload)
+        except:
+            return False
+        else:
+            return True
+
+    def get_plugin_queryset(self):
+        plugins = (
+            CMSPlugin
+            .objects
+            .select_related('placeholder')
+            .filter(
+                Q(plugin_type=self.plugin_type)|
+                Q(parent__plugin_type=self.plugin_type)
+            )
+        )
+        return plugins
 
 
 class TextForm(ModelForm):

--- a/djangocms_text_ckeditor/forms.py
+++ b/djangocms_text_ckeditor/forms.py
@@ -58,6 +58,10 @@ class DeleteOnCancelForm(forms.Form):
 
     def is_valid_token(self, session_id):
         plugin = self.cleaned_data['plugin']
+
+        if plugin.plugin_type != self.text_plugin_type:
+            plugin = plugin.parent
+
         plugin_id = force_text(plugin.pk)
         payload = ':'.join([plugin_id, self.cleaned_data['token']])
 

--- a/djangocms_text_ckeditor/forms.py
+++ b/djangocms_text_ckeditor/forms.py
@@ -2,7 +2,6 @@
 from django import forms
 from django.core import signing
 from django.core.signing import BadSignature
-from django.db.models import Q
 from django.forms.models import ModelForm
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext
@@ -14,55 +13,30 @@ from .utils import plugin_tags_to_id_list
 
 
 class DeleteOnCancelForm(forms.Form):
-    plugin = forms.ModelChoiceField(
+    child_plugins = forms.ModelMultipleChoiceField(
         queryset=CMSPlugin.objects.none(),
-        required=True,
+        required=False,
     )
     token = forms.CharField(required=True)
 
     def __init__(self, *args, **kwargs):
-        self.text_plugin_type = kwargs.pop('text_plugin_type')
+        self.text_plugin = kwargs.pop('text_plugin')
         super(DeleteOnCancelForm, self).__init__(*args, **kwargs)
-        self.fields['plugin'].queryset = self.get_plugin_queryset()
+        self.fields['child_plugins'].queryset = self.get_child_plugins()
 
     def clean(self):
-        plugin = self.cleaned_data['plugin']
+        children = self.cleaned_data.get('child_plugins')
 
-        if plugin.plugin_type == self.text_plugin_type:
-            text_plugin = plugin.get_plugin_instance()[0]
-
-            if text_plugin:
-                # Plugin has been saved
-                # This check prevents users from using a cancel token
-                # to delete any text plugin.
-                # Only non-saved text plugins can be deleted.
-                message = ugettext("Can't delete a saved plugin.")
-                raise forms.ValidationError(message, code='invalid')
-            return self.cleaned_data
-
-        text_plugin = plugin.parent.get_plugin_instance()[0]
-
-        if text_plugin:
-            plugin_ids = plugin_tags_to_id_list(text_plugin.body)
-        else:
-            plugin_ids = []
-
-        if plugin.pk in plugin_ids:
-            # Plugin has been saved
+        if not children and self.text_plugin.get_plugin_instance()[0]:
             # This check prevents users from using a cancel token
-            # to delete any child of the text plugin.
-            # Only non-saved children can be deleted.
+            # to delete just any text plugin.
+            # Only non-saved text plugins can be deleted.
             message = ugettext("Can't delete a saved plugin.")
             raise forms.ValidationError(message, code='invalid')
         return self.cleaned_data
 
     def is_valid_token(self, session_id):
-        plugin = self.cleaned_data['plugin']
-
-        if plugin.plugin_type != self.text_plugin_type:
-            plugin = plugin.parent
-
-        plugin_id = force_text(plugin.pk)
+        plugin_id = force_text(self.text_plugin.pk)
         payload = ':'.join([plugin_id, self.cleaned_data['token']])
 
         signer = signing.Signer(salt=session_id)
@@ -74,17 +48,31 @@ class DeleteOnCancelForm(forms.Form):
         else:
             return True
 
-    def get_plugin_queryset(self):
-        plugins = (
-            CMSPlugin
-            .objects
-            .select_related('placeholder', 'parent')
-            .filter(
-                Q(plugin_type=self.text_plugin_type)|
-                Q(parent__plugin_type=self.text_plugin_type)
-            )
-        )
-        return plugins
+    def get_child_plugins(self):
+        # We use this queryset to limit the plugins
+        # a user can delete to only plugins that have not
+        # been saved in text and are descendants of the text plugin.
+        instance = self.text_plugin.get_plugin_instance()[0]
+
+        if instance:
+            # Only non-saved children can be deleted.
+            excluded_plugins = plugin_tags_to_id_list(instance.body)
+        else:
+            excluded_plugins = []
+
+        queryset = self.text_plugin.get_descendants()
+
+        if excluded_plugins:
+            queryset = queryset.exclude(pk__in=excluded_plugins)
+        return queryset
+
+    def delete(self):
+        child_plugins = self.cleaned_data.get('child_plugins')
+
+        if child_plugins:
+            child_plugins.delete()
+        else:
+            self.text_plugin.delete()
 
 
 class TextForm(ModelForm):

--- a/djangocms_text_ckeditor/forms.py
+++ b/djangocms_text_ckeditor/forms.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from django import forms
 from django.core import signing
+from django.core.signing import BadSignature
 from django.db.models import Q
 from django.forms.models import ModelForm
 from django.utils.encoding import force_text
@@ -64,7 +65,7 @@ class DeleteOnCancelForm(forms.Form):
 
         try:
             signer.unsign(payload)
-        except:
+        except BadSignature:
             return False
         else:
             return True

--- a/djangocms_text_ckeditor/static/djangocms_text_ckeditor/ckeditor_plugins/cmsplugins/plugin.js
+++ b/djangocms_text_ckeditor/static/djangocms_text_ckeditor/ckeditor_plugins/cmsplugins/plugin.js
@@ -282,7 +282,7 @@ $(document).ready(function () {
                     }).done(function (res) {
                         console.log(data);
                         console.log(that);
-                        CMS.API.Helpers.removeEventListener('modal-close', cancelModalCallback);
+                        CMS.API.Helpers.removeEventListener('modal-close.' + data.plugin_id);
                         console.log('oi!', res);
                     }).fail(function (res) {
                         CMS.API.Messages.open({
@@ -296,7 +296,7 @@ $(document).ready(function () {
                     that.tryToCloseModal(opts.instance);
                 }
             };
-            CMS.API.Helpers.addEventListener('modal-close', cancelModalCallback);
+            CMS.API.Helpers.addEventListener('modal-close.' + data.plugin_id, cancelModalCallback);
         },
 
         /**

--- a/djangocms_text_ckeditor/static/djangocms_text_ckeditor/ckeditor_plugins/cmsplugins/plugin.js
+++ b/djangocms_text_ckeditor/static/djangocms_text_ckeditor/ckeditor_plugins/cmsplugins/plugin.js
@@ -284,7 +284,7 @@ $(document).ready(function () {
                         console.log(that);
                         CMS.API.Helpers.removeEventListener('modal-close', cancelModalCallback);
                         console.log('oi!', res);
-                    }).error(function (res) {
+                    }).fail(function (res) {
                         CMS.API.Messages.open({
                             message: res.responseText + ' | ' + res.status + ' ' + res.statusText,
                             delay: 0,

--- a/djangocms_text_ckeditor/static/djangocms_text_ckeditor/ckeditor_plugins/cmsplugins/plugin.js
+++ b/djangocms_text_ckeditor/static/djangocms_text_ckeditor/ckeditor_plugins/cmsplugins/plugin.js
@@ -317,7 +317,10 @@ $(document).ready(function () {
                     that.tryToCloseModal(modal);
                 }
             }, function failure () {
-                console.error('Cancel request failed.');
+                window.parent.CMS.API.Messages.open({
+                    error: true,
+                    message: 'Cancel request failed'
+                });
             });
         },
 

--- a/djangocms_text_ckeditor/static/djangocms_text_ckeditor/ckeditor_plugins/cmsplugins/plugin.js
+++ b/djangocms_text_ckeditor/static/djangocms_text_ckeditor/ckeditor_plugins/cmsplugins/plugin.js
@@ -246,7 +246,11 @@ $(document).ready(function () {
             }
             element.setAttributes(attrs);
 
-            this.setupCancelCleanupCallback(data);
+            // in case it's a fresh text plugin children don't have to be
+            // deleted separately
+            if (!this.options.delete_on_cancel) {
+                this.setupCancelCleanupCallback(data);
+            }
             this.editor.insertElement(element);
         },
 

--- a/djangocms_text_ckeditor/static/djangocms_text_ckeditor/ckeditor_plugins/cmsplugins/plugin.js
+++ b/djangocms_text_ckeditor/static/djangocms_text_ckeditor/ckeditor_plugins/cmsplugins/plugin.js
@@ -285,9 +285,11 @@ $(document).ready(function () {
                         CMS.API.Helpers.removeEventListener('modal-close', cancelModalCallback);
                         console.log('oi!', res);
                     }).error(function (res) {
-                        console.log(data);
-                        console.log(that);
-                        console.log('error!', res);
+                        CMS.API.Messages.open({
+                            message: res.responseText + ' | ' + res.status + ' ' + res.statusText,
+                            delay: 0,
+                            error: true
+                        });
                     });
 
                     that.cancelPromises.push(deferred);

--- a/djangocms_text_ckeditor/static/djangocms_text_ckeditor/ckeditor_plugins/cmsplugins/plugin.js
+++ b/djangocms_text_ckeditor/static/djangocms_text_ckeditor/ckeditor_plugins/cmsplugins/plugin.js
@@ -266,12 +266,15 @@ $(document).ready(function () {
             var that = this;
             var CMS = window.parent.CMS;
             var cancelModalCallback = function cancelModalCallback(e, opts) {
+                if (!that.options.delete_on_cancel && !that.child_plugins.length) {
+                    return;
+                }
                 e.preventDefault();
                 CMS.API.Toolbar.showLoader();
                 var data = {
                     token: that.options.cancel_plugin_token
                 };
-                if (!that.options.delete_on_cancel ) {
+                if (!that.options.delete_on_cancel) {
                     data.child_plugins = that.child_plugins;
                 }
                 $.ajax({

--- a/djangocms_text_ckeditor/static/djangocms_text_ckeditor/ckeditor_plugins/cmsplugins/plugin.js
+++ b/djangocms_text_ckeditor/static/djangocms_text_ckeditor/ckeditor_plugins/cmsplugins/plugin.js
@@ -274,22 +274,20 @@ $(document).ready(function () {
                     CMS.API.Toolbar.showLoader();
                     var deferred = $.ajax({
                         method: 'POST',
-                        url: data.cancel_plugin_url,
+                        url: that.options.cancel_plugin_url,
                         data: {
                             plugin: data.plugin_id,
-                            token: data.cancel_plugin_token
+                            token: that.options.cancel_plugin_token
                         }
                     }).done(function (res) {
                         console.log(data);
                         console.log(that);
                         CMS.API.Helpers.removeEventListener('modal-close', cancelModalCallback);
                         console.log('oi!', res);
-                        debugger
                     }).error(function (res) {
                         console.log(data);
                         console.log(that);
                         console.log('error!', res);
-                        debugger
                     });
 
                     that.cancelPromises.push(deferred);

--- a/djangocms_text_ckeditor/static/djangocms_text_ckeditor/ckeditor_plugins/cmsplugins/plugin.js
+++ b/djangocms_text_ckeditor/static/djangocms_text_ckeditor/ckeditor_plugins/cmsplugins/plugin.js
@@ -280,10 +280,7 @@ $(document).ready(function () {
                             token: that.options.cancel_plugin_token
                         }
                     }).done(function (res) {
-                        console.log(data);
-                        console.log(that);
                         CMS.API.Helpers.removeEventListener('modal-close.' + data.plugin_id);
-                        console.log('oi!', res);
                     }).fail(function (res) {
                         CMS.API.Messages.open({
                             message: res.responseText + ' | ' + res.status + ' ' + res.statusText,

--- a/djangocms_text_ckeditor/static/djangocms_text_ckeditor/ckeditor_plugins/cmsplugins/plugin.js
+++ b/djangocms_text_ckeditor/static/djangocms_text_ckeditor/ckeditor_plugins/cmsplugins/plugin.js
@@ -192,22 +192,7 @@ $(document).ready(function () {
                 'plugin_language':  this.options.plugin_language
             };
 
-            // lets do some ajax
-            $.ajax({
-                'type': 'POST',
-                'url': this.options.add_plugin_url,
-                'data': data,
-                'success': function (data) {
-                    // cancel if error is returned
-                    if(data === 'error') return false;
-
-                    // trigger dialog
-                    that.addPluginDialog(item, data);
-                },
-                'error': function (error) {
-                    alert('There was an error creating the plugin.');
-                }
-            });
+            that.addPluginDialog(item, data);
         },
 
         addPluginDialog: function (item, data) {
@@ -221,14 +206,13 @@ $(document).ready(function () {
             dialog.resize(body.width() * 0.8, body.height() * 0.7);
             $(dialog.getElement().$).addClass('cms-ckeditor-dialog');
             $(dialog.parts.title.$).text(this.options.lang.add);
-            $(dialog.parts.contents.$).find('iframe').attr('src', data.url)
+            $(dialog.parts.contents.$).find('iframe').attr('src', this.options.add_plugin_url + '?' + $.param(data))
                 .bind('load', function () {
                     $(this).contents().find('.submit-row').hide().end()
                     .find('#container').css('min-width', 0).css('padding', 0)
                     .find('#id_name').val(selected_text);
                 });
         },
-
         // on ajax receivement from server, build <a> or <img> tag dependig in the plugin type
         insertPlugin: function (data) {
             var element, attrs = { id: 'plugin_obj_' + data.plugin_id };

--- a/djangocms_text_ckeditor/static/djangocms_text_ckeditor/js/cms.ckeditor.js
+++ b/djangocms_text_ckeditor/static/djangocms_text_ckeditor/js/cms.ckeditor.js
@@ -84,7 +84,11 @@ $(document).ready(function () {
                 that.editor.resize('100%', win.CMS.$('.cms-modal-frame').height() - 70);
                 this.editor.execCommand('maximize');
                 win.CMS.API.Helpers.addEventListener('modal-maximized modal-restored', function (e, payload) {
-                    that.editor.resize('100%', win.CMS.$('.cms-modal-frame').height() - 70);
+                    try {
+                        that.editor.resize('100%', win.CMS.$('.cms-modal-frame').height() - 70);
+                    } catch (e) {
+                        // sometimes throws errors if modal with text plugin is closed too fast
+                    }
                 });
             }
 

--- a/djangocms_text_ckeditor/templates/admin/cms/page/plugin/confirm_form.html
+++ b/djangocms_text_ckeditor/templates/admin/cms/page/plugin/confirm_form.html
@@ -1,9 +1,0 @@
-{% extends "admin/cms/page/close_frame.html" %}
-{% block content %}
-{{ block.super }}
-<script>
-    (function(Window) {
-        Window.CMS.API.Helpers.dataBridge['plugin_cancel'] = 'value'
-    })(window.parent || window);
-</script>
-{% endblock content %}

--- a/djangocms_text_ckeditor/templates/admin/cms/page/plugin/confirm_form.html
+++ b/djangocms_text_ckeditor/templates/admin/cms/page/plugin/confirm_form.html
@@ -1,0 +1,9 @@
+{% extends "admin/cms/page/close_frame.html" %}
+{% block content %}
+{{ block.super }}
+<script>
+    (function(Window) {
+        Window.CMS.API.Helpers.dataBridge['plugin_cancel'] = 'value'
+    })(window.parent || window);
+</script>
+{% endblock content %}

--- a/djangocms_text_ckeditor/templates/cms/plugins/widgets/ckeditor.html
+++ b/djangocms_text_ckeditor/templates/cms/plugins/widgets/ckeditor.html
@@ -24,6 +24,12 @@ $(document).ready(function () {
 				CMS.CKEditor.init(container, {{ settings|safe }}, {
 					'static_url': '{{ STATIC_URL }}djangocms_text_ckeditor',
 					'add_plugin_url': '{{ placeholder.get_add_url }}',
+					{% if widget.cancel_url %}
+					'cancel_plugin_url': '{{ widget.cancel_url }}',
+					{% endif %}
+					{% if widget.cancel_url and widget.cancel_token %}
+					'cancel_plugin_token': '{{ widget.cancel_token }}',
+					{% endif %}
 					'placeholder_id': {{ placeholder.pk|default:"''"|unlocalize }},
 					'plugin_id': {{ plugin_pk|default:"''"|unlocalize }},
 					'plugin_language': '{{ plugin_language }}',

--- a/djangocms_text_ckeditor/templates/cms/plugins/widgets/ckeditor.html
+++ b/djangocms_text_ckeditor/templates/cms/plugins/widgets/ckeditor.html
@@ -24,12 +24,11 @@ $(document).ready(function () {
 				CMS.CKEditor.init(container, {{ settings|safe }}, {
 					'static_url': '{{ STATIC_URL }}djangocms_text_ckeditor',
 					'add_plugin_url': '{{ placeholder.get_add_url }}',
-					{% if widget.cancel_url %}
-					'cancel_plugin_url': '{{ widget.cancel_url }}',
-					{% endif %}
 					{% if widget.cancel_url and widget.cancel_token %}
+					'cancel_plugin_url': '{{ widget.cancel_url }}',
 					'cancel_plugin_token': '{{ widget.cancel_token }}',
 					{% endif %}
+					'delete_on_cancel': {{ widget.delete_on_cancel|yesno:"true,false" }},
 					'placeholder_id': {{ placeholder.pk|default:"''"|unlocalize }},
 					'plugin_id': {{ plugin_pk|default:"''"|unlocalize }},
 					'plugin_language': '{{ plugin_language }}',

--- a/djangocms_text_ckeditor/tests/test_plugin.py
+++ b/djangocms_text_ckeditor/tests/test_plugin.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
+import re
 
 from cms.api import create_page
 from cms.models import CMSPlugin, Page
@@ -19,20 +20,10 @@ class PluginActionsTestCase(CMSTestCase, BaseTestCase):
     def get_post_request(self, data):
         return self.get_request(post_data=data)
 
-    def get_plugin_id_from_response(self, response, path):
-        # Expects response to be a JSON response
-        # with a structure like so:
-        # {'path.1': {
-        #   'path.2': '/en/admin/app/example1/edit-plugin/3/'}
-        # }
-        # path is used to access nested keys
-
-        data = json.loads(response.content.decode('utf-8'))
-        keys = path.split('.')
-
-        for key in keys:
-            data = data[key]
-        return data.split('/')[-2]
+    def get_plugin_id_from_response(self, response):
+        # Ideal case, this looks like:
+        # /en/admin/cms/page/edit-plugin/1/
+        return re.findall('\d+', response.url)[0]
 
     def test_add_and_edit_plugin(self):
         """
@@ -43,27 +34,38 @@ class PluginActionsTestCase(CMSTestCase, BaseTestCase):
 
         native_placeholder_admin = self.get_page_admin()
 
-        request = self.get_post_request({
+        request = self.get_request()
+        request.GET = {
             'plugin_type': 'TextPlugin',
             'placeholder_id': simple_placeholder.pk,
             'plugin_language': 'en',
             'plugin_parent': '',
-        })
+        }
         response = native_placeholder_admin.add_plugin(request)
 
-        self.assertEqual(response.status_code, 200)
+        text_plugin_pk = self.get_plugin_id_from_response(response)
 
-        # Point to the newly created text plugin
-        text_plugin_pk = self.get_plugin_id_from_response(
-            response,
-            path='url',
-        )
+        self.assertIn('?delete-on-cancel', response.url)
+        self.assertEqual(response.status_code, 302)
 
         # Assert "ghost" plugin has been created
         self.assertObjectExist(CMSPlugin.objects.all(), pk=text_plugin_pk)
 
+        cms_plugin = CMSPlugin.objects.get(pk=text_plugin_pk)
+        text_plugin_class = cms_plugin.get_plugin_class_instance()
+
         # Assert "real" plugin has not been created yet
         self.assertObjectDoesNotExist(Text.objects.all(), pk=text_plugin_pk)
+
+        with self.login_user_context(self.get_superuser()):
+            request = self.get_request()
+            cancel_token = text_plugin_class.get_cancel_token(request, cms_plugin)
+            response = self.client.get(response.url)
+
+            self.assertEqual(response.status_code, 200)
+
+            # Assert cancel token is present
+            self.assertContains(response, cancel_token)
 
         request = self.get_post_request({'body': "Hello world"})
         response = native_placeholder_admin.edit_plugin(request, text_plugin_pk)
@@ -78,7 +80,6 @@ class PluginActionsTestCase(CMSTestCase, BaseTestCase):
         # Assert the text was correctly saved
         self.assertEqual(text_plugin.body, "Hello world")
 
-
     def test_add_and_cancel_plugin(self):
         """
         Test that you can add a text plugin
@@ -88,29 +89,33 @@ class PluginActionsTestCase(CMSTestCase, BaseTestCase):
 
         native_placeholder_admin = self.get_page_admin()
 
-        request = self.get_post_request({
+        request = self.get_request()
+        request.GET = {
             'plugin_type': 'TextPlugin',
             'placeholder_id': simple_placeholder.pk,
             'plugin_language': 'en',
             'plugin_parent': '',
-        })
+        }
+
         response = native_placeholder_admin.add_plugin(request)
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 302)
 
         # Point to the newly created text plugin
-        text_plugin_pk = self.get_plugin_id_from_response(
-            response,
-            path='url',
-        )
+        text_plugin_pk = self.get_plugin_id_from_response(response)
+        cms_plugin = CMSPlugin.objects.get(pk=text_plugin_pk)
+        text_plugin_class = cms_plugin.get_plugin_class_instance()
 
         # Assert "ghost" plugin has been created
         self.assertObjectExist(CMSPlugin.objects.all(), pk=text_plugin_pk)
 
-        request = self.get_post_request({'body': "Hello world", '_cancel': True})
-        response = native_placeholder_admin.edit_plugin(request, text_plugin_pk)
-
-        self.assertEqual(response.status_code, 200)
+        with self.login_user_context(self.get_superuser()):
+            request = self.get_request()
+            cancel_token = text_plugin_class.get_cancel_token(request, cms_plugin)
+            data = {'plugin': text_plugin_pk, 'token': cancel_token}
+            request = self.get_post_request(data)
+            response = text_plugin_class.delete_on_cancel(request)
+            self.assertEqual(response.status_code, 204)
 
         # Assert "ghost" plugin has been removed
         self.assertObjectDoesNotExist(CMSPlugin.objects.all(), pk=text_plugin_pk)

--- a/djangocms_text_ckeditor/widgets.py
+++ b/djangocms_text_ckeditor/widgets.py
@@ -15,7 +15,7 @@ class TextEditorWidget(Textarea):
 
     def __init__(self, attrs=None, installed_plugins=None, pk=None,
                  placeholder=None, plugin_language=None, configuration=None,
-                 cancel_url=None, cancel_token=None):
+                 cancel_url=None, cancel_token=None, delete_on_cancel=False):
         """
         Create a widget for editing text + plugins.
 
@@ -43,6 +43,7 @@ class TextEditorWidget(Textarea):
             self.configuration = text_settings.CKEDITOR_SETTINGS
         self.cancel_url = cancel_url
         self.cancel_token = cancel_token
+        self.delete_on_cancel = delete_on_cancel
 
     def render_textarea(self, name, value, attrs=None):
         return super(TextEditorWidget, self).render(name, value, attrs)

--- a/djangocms_text_ckeditor/widgets.py
+++ b/djangocms_text_ckeditor/widgets.py
@@ -12,8 +12,10 @@ from . import settings as text_settings
 
 
 class TextEditorWidget(Textarea):
+
     def __init__(self, attrs=None, installed_plugins=None, pk=None,
-                 placeholder=None, plugin_language=None, configuration=None):
+                 placeholder=None, plugin_language=None, configuration=None,
+                 cancel_url=None, cancel_token=None):
         """
         Create a widget for editing text + plugins.
 
@@ -39,6 +41,8 @@ class TextEditorWidget(Textarea):
             self.configuration = conf
         else:
             self.configuration = text_settings.CKEDITOR_SETTINGS
+        self.cancel_url = cancel_url
+        self.cancel_token = cancel_token
 
     def render_textarea(self, name, value, attrs=None):
         return super(TextEditorWidget, self).render(name, value, attrs)
@@ -71,7 +75,8 @@ class TextEditorWidget(Textarea):
             'installed_plugins': self.installed_plugins,
             'plugin_pk': self.pk,
             'plugin_language': self.plugin_language,
-            'placeholder': self.placeholder
+            'placeholder': self.placeholder,
+            'widget': self,
         }
         return mark_safe(render_to_string('cms/plugins/widgets/ckeditor.html', context))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-django-cms>=3.0
+https://github.com/czpython/django-cms/zipball/feature/sane-add-plugin-v3
 html5lib>=0.999999
 Pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-https://github.com/czpython/django-cms/zipball/feature/sane-add-plugin-v3
+django-cms>=3.3
 html5lib>=0.999999
 Pillow

--- a/tox.ini
+++ b/tox.ini
@@ -1,24 +1,14 @@
 [tox]
 envlist =
-    py{26}-django{16}-cms{30,31}
-    py{27,34,35}-django{16,17}-cms{30}
-    py{27,34,35}-django{16,17,18}-cms{31,32}
-    py{27,34,35}-django{19}-cms{32}
+    py{27,34,35}-django{18,19}-cms33
 skip_missing_interpreters=True
 
 [testenv]
 commands = {env:COMMAND:python} setup.py test
 
 deps =
-    cms30: https://github.com/divio/django-cms/archive/support/3.0.x.zip
-    cms31: https://github.com/divio/django-cms/archive/support/3.1.x.zip
-    cms32: https://github.com/divio/django-cms/archive/release/3.2.x.zip
-    cmsdev: https://github.com/divio/django-cms/archive/develop.zip
+    cms33: https://github.com/czpython/django-cms/archive/feature/sane-add-plugin-v3.zip
     https://github.com/nephila/djangocms-helper/archive/develop.zip
-    django16: django<1.7
-    django16: django-treebeard<4.0
-    django16: https://github.com/divio/django-formtools/archive/master.zip#egg=django-formtools
-    django17: django<1.8
     django18: django<1.9
     django19: django<1.10
     Pillow

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ skip_missing_interpreters=True
 commands = {env:COMMAND:python} setup.py test
 
 deps =
-    cms33: https://github.com/czpython/django-cms/archive/feature/sane-add-plugin-v3.zip
+    cms33: https://github.com/divio/django-cms/archive/develop.zip
     https://github.com/nephila/djangocms-helper/archive/develop.zip
     django18: django<1.9
     django19: django<1.10


### PR DESCRIPTION
* Fixed backwards compatiblity with projects that already have "ghost" text plugins.
* Canceling text plugin now correctly removes the cmsplugin record.
* Canceling a child plugin of the text plugin correctly removes the child plugin.
