### PR TITLE
Work around parler caching

### DIFF
--- a/djangocms_text_ckeditor/fields.py
+++ b/djangocms_text_ckeditor/fields.py
@@ -32,7 +32,15 @@ class HTMLFormField(CharField):
 
     def clean(self, value):
         value = super(HTMLFormField, self).clean(value)
-        return clean_html(value, full=False)
+        clean_value = clean_html(value, full=False)
+
+        # We `mark_safe` here (as well as in the correct places) because Django
+        # Parler cache's the value directly from the in-memory object as it
+        # also stores the value in the database. So the cached version is never
+        # processed by `from_db_value()`.
+        clean_value = mark_safe(clean_value)
+
+        return clean_value
 
 
 class HTMLField(models.TextField):

--- a/djangocms_text_ckeditor/tests/test_field.py
+++ b/djangocms_text_ckeditor/tests/test_field.py
@@ -1,10 +1,20 @@
 # -*- coding: utf-8 -*-
+
 from django.template import Context, Template
+from django.utils.safestring import SafeData
 
 from djangocms_helper.base_test import BaseTestCase
 
+from djangocms_text_ckeditor.fields import HTMLFormField
 from djangocms_text_ckeditor.test_app.forms import SimpleTextForm
 from djangocms_text_ckeditor.test_app.models import SimpleText
+
+
+class HtmlFieldTestCase(BaseTestCase):
+
+    def test_html_form_field(self):
+        html_field = HTMLFormField()
+        self.assertTrue(isinstance(html_field.clean("some text"), SafeData))
 
 
 class FieldTestCase(BaseTestCase):


### PR DESCRIPTION
When an HTMLField is used as a Django Parler translated field, it intercepts field content as it is being saved to the DB and stored in Parler's internal cache. This intercepted content never had a chance to be marked safe by this package's from_db_value() method.

This PR adds the idemopotent `mark_safe` to the HTMLFormField's clean() method too.