### PR TITLE
fix remaining cms.base reference

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+3.0.1 (unreleased)
+------------------
+
+* Replace remaining CMS base module with CMS admin bundle that was missed in
+  2.8.0
+
+
 3.0.0 (2016-05-26)
 ------------------
 

--- a/djangocms_text_ckeditor/templates/cms/plugins/widgets/ckeditor.html
+++ b/djangocms_text_ckeditor/templates/cms/plugins/widgets/ckeditor.html
@@ -6,7 +6,7 @@
 
 {% block extrahead %}
 <script>window.CKEDITOR_BASEPATH = "{{ CKEDITOR_BASEPATH }}";</script>
-<script src="{% static "cms/js/dist/bundle.admin.base.js" %}"></script>
+<script src="{% static "cms/js/dist/bundle.admin.base.min.js" %}"></script>
 <script src="{% static "djangocms_text_ckeditor/ckeditor/ckeditor.js" %}"></script>
 <script src="{% static "djangocms_text_ckeditor/js/cms.ckeditor.js" %}"></script>
 {% endblock %}

--- a/djangocms_text_ckeditor/templates/cms/plugins/widgets/ckeditor.html
+++ b/djangocms_text_ckeditor/templates/cms/plugins/widgets/ckeditor.html
@@ -6,7 +6,7 @@
 
 {% block extrahead %}
 <script>window.CKEDITOR_BASEPATH = "{{ CKEDITOR_BASEPATH }}";</script>
-<script src="{% static "cms/js/modules/cms.base.js" %}"></script>
+<script src="{% static "cms/js/dist/bundle.admin.base.js" %}"></script>
 <script src="{% static "djangocms_text_ckeditor/ckeditor/ckeditor.js" %}"></script>
 <script src="{% static "djangocms_text_ckeditor/js/cms.ckeditor.js" %}"></script>
 {% endblock %}


### PR DESCRIPTION
in CMS  3.3.1 we are switching to webpack bundling and referencing cms modules will break 3rd party code 
this reference was missed in 2.8.0 but didn't affect much. after 3.3.1 it will definitely break