### PR TITLE
freeze html5lib-python<0.99999999/1.0b9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from djangocms_text_ckeditor import __version__
 
 INSTALL_REQUIRES = [
     'django-cms>=3.3.0',
-    'html5lib>=0.90,!=0.9999,!=0.99999',
+    'html5lib>=0.90,!=0.9999,!=0.99999,<0.99999999',
     'Pillow',
 ]
 


### PR DESCRIPTION
v1.0b9 removed the ``sanitizer`` package which we depend on
https://github.com/html5lib/html5lib-python/blob/master/CHANGES.rst#09999999910b9