### PR TITLE
Text align widgets

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 CHANGELOG
 =========
 
+3.1.0 (unreleased)
+------------------
+
+* Added support for inline preview of text enabled CMS plugins
+* Added support for plugins to declare "text_editor_preview=False" in order for
+  them to be rendered with old-style label (useful for plugins with no valuable
+  visual representation, such as snippet, spacer, etc).
+
+
 3.0.1 (2016-07-15)
 ------------------
 

--- a/djangocms_text_ckeditor/static/djangocms_text_ckeditor/js/cms.ckeditor.js
+++ b/djangocms_text_ckeditor/static/djangocms_text_ckeditor/js/cms.ckeditor.js
@@ -57,7 +57,6 @@
 
                     document.createElement('cms-plugin');
                     CKEDITOR.dtd['cms-plugin'] = CKEDITOR.dtd.div;
-                    CKEDITOR.dtd.$block['cms-plugin'] = 1;
                     CKEDITOR.dtd.$inline['cms-plugin'] = 1;
                     CKEDITOR.dtd.$transparent['cms-plugin'] = 1;
                     CKEDITOR.dtd.$nonEditable['cms-plugin'] = 1;


### PR DESCRIPTION
Block level widgets were being unwrapped incorrectly and ckeditor
own markup was leaking into user content. Same for inline plugins
which were not aligning at all.

Now if the widget is not "alignable" the command will be disabled.