### PR TITLE
Fixed block level plugins wrapped with paragraphs breaking markup

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ CHANGELOG
 * Introduced support for djangoCMS 3.4.0
 * Fixed a JavaScript issue when using TextEditorWidget or HTMLField
 * Added native Aldryn support
+* Fixed a bug where invalid markup created by previous versions of the plugin
+  would result in a broken markup after upgrading
 
 
 3.1.0 (2016-08-18)


### PR DESCRIPTION
Previous versions of the addon assumed that every plugin is an inline
plugin, which could result in the block level markup wrapped with a `<p>` tag
With new system in place it is no longer allowed, but previous markup
could potentially be broken on first edit.

Ref: #353