### PR TITLE
Fixed a bug with disappearing whitespace before "inline" plugins

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ CHANGELOG
 * Added native Aldryn support
 * Fixed a bug where invalid markup created by previous versions of the plugin
   would result in a broken markup after upgrading
+* Fixed a bug where whitespace would be incorrectly removed before the child
+  plugin on save of the text plugin
 
 
 3.1.0 (2016-08-18)

--- a/djangocms_text_ckeditor/static/djangocms_text_ckeditor/js/cms.ckeditor.js
+++ b/djangocms_text_ckeditor/static/djangocms_text_ckeditor/js/cms.ckeditor.js
@@ -59,7 +59,6 @@
                     CKEDITOR.dtd['cms-plugin'] = CKEDITOR.dtd.div;
                     CKEDITOR.dtd.$inline['cms-plugin'] = 1;
                     CKEDITOR.dtd.$transparent['cms-plugin'] = 1;
-                    CKEDITOR.dtd.$nonEditable['cms-plugin'] = 1;
                     CKEDITOR.dtd.body['cms-plugin'] = 1;
 
                     // add additional plugins (autoloads plugins.js)


### PR DESCRIPTION
We were setting the `cms-plugin` tag as a nonEditable but that's not
really needed since the widgets are non-editable anyway. What it did was
setting "isBlockLike" property on ckeditor html parser elements, which
in turn trimmed whitespace on the right of any text node preceding this
`cms-plugin` while it was parsing, which would result in e.g. links sticking to the text
before them.

Ref: https://github.com/ckeditor/ckeditor-dev/blob/12f0de314fd6fbee0bc4d35d541123d283fdecc9/core/htmlparser/fragment.js#L484