### PR TITLE
Add django CMS 3.4 to tox - pin djangocms-picture

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{27,34,35}-django{18,19}-cms33
+    py{27,34,35}-django{18,19}-cms{33,34}
 skip_missing_interpreters=True
 
 [testenv]
@@ -15,7 +15,7 @@ deps =
     Pillow
     html5lib>=0.999999
     coverage
-    djangocms-picture
+    djangocms-picture<2.0
     djangocms-link
 
 [testenv:isort]


### PR DESCRIPTION
django CMS 3.4 was not enabled in tox
djangocms-picture 2.0 is filer enabled, tests needs changes. Pinning to <2.0 to get further PR pass