### PR TITLE
Fixed a bug with extra whitespace appearing around child plugins

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,5 +19,5 @@ max_line_length = 120
 [*.rst]
 max_line_length = 80
 
-[djangocms_text_ckeditor/templates/mcs/plugins/render_plugin_preview.html]
+[djangocms_text_ckeditor/templates/cms/plugins/render_plugin_preview.html]
 insert_final_newline = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -18,3 +18,6 @@ max_line_length = 120
 
 [*.rst]
 max_line_length = 80
+
+[djangocms_text_ckeditor/templates/mcs/plugins/render_plugin_preview.html]
+insert_final_newline = false

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ CHANGELOG
 
 * Fixed a problem with editing links that are not CMS plugins
 * Fixed a problem with prefilling fields when editing CMS plugins
+* Fixed a bug with extra whitespace appearing around plugin rendered inside of
+  the text plugin
 
 3.2.1 (2016-09-14)
 ------------------

--- a/djangocms_text_ckeditor/templates/cms/plugins/render_plugin_preview.html
+++ b/djangocms_text_ckeditor/templates/cms/plugins/render_plugin_preview.html
@@ -1,2 +1,1 @@
-{% load djangocms_text_ckeditor_tags %}
-{% render_plugin_preview plugin %}
+{% load djangocms_text_ckeditor_tags %}{% render_plugin_preview plugin %}

--- a/djangocms_text_ckeditor/tests/test_plugin.py
+++ b/djangocms_text_ckeditor/tests/test_plugin.py
@@ -511,11 +511,13 @@ class PluginActionsTestCase(CMSTestCase, BaseTestCase):
 
             self.assertEqual(response.status_code, 200)
 
+            # it is important that we do not add any extra whitespace inside of
+            # <cms-plugin></cms-plugin>
             rendered_child_plugin = ('<cms-plugin render-plugin=false '
                                      'alt="Preview Disabled Plugin - 3 '
                                      '"title="Preview Disabled Plugin - 3" '
-                                     'id="3">\n<span>Preview is disabled for this plugin</span>'
-                                     '\n</cms-plugin>')
+                                     'id="3"><span>Preview is disabled for this plugin</span>'
+                                     '</cms-plugin>')
 
             self.assertEqual(force_text(response.content), rendered_child_plugin)
 


### PR DESCRIPTION
so before it was:
```
Here is a <cms-plugin ...>
<a href="...">link</a>
</cms-plugin>.
```
(note the newline before closing `<cms-plugin>` tag) - it would render like `Here is a link .` (space before point).

now it is:
```
Here is a <cms-plugin ...><a href="...">link</a></cms-plugin>.
```

which would render as `Here is a link.`.