### PR TITLE
Added missing DjangoJSONEncoder to json.dumps

### DIFF
--- a/djangocms_text_ckeditor/widgets.py
+++ b/djangocms_text_ckeditor/widgets.py
@@ -73,7 +73,8 @@ class TextEditorWidget(Textarea):
             'ckeditor_function': ckeditor_selector.replace('-', '_'),
             'name': name,
             'language': language,
-            'settings': language.join(json.dumps(configuration, cls=DjangoJSONEncoder).split("{{ language }}")),
+            'settings': language.join(json.dumps(configuration, cls=DjangoJSONEncoder) \
+                                .split("{{ language }}")),
             'STATIC_URL': settings.STATIC_URL,
             'CKEDITOR_BASEPATH': text_settings.TEXT_CKEDITOR_BASE_PATH,
             'installed_plugins': self.installed_plugins,

--- a/djangocms_text_ckeditor/widgets.py
+++ b/djangocms_text_ckeditor/widgets.py
@@ -3,6 +3,7 @@ import json
 from copy import deepcopy
 
 from django.conf import settings
+from django.core.serializers.json import DjangoJSONEncoder
 from django.forms import Textarea
 from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
@@ -72,7 +73,7 @@ class TextEditorWidget(Textarea):
             'ckeditor_function': ckeditor_selector.replace('-', '_'),
             'name': name,
             'language': language,
-            'settings': language.join(json.dumps(configuration).split("{{ language }}")),
+            'settings': language.join(json.dumps(configuration, cls=DjangoJSONEncoder).split("{{ language }}")),
             'STATIC_URL': settings.STATIC_URL,
             'CKEDITOR_BASEPATH': text_settings.TEXT_CKEDITOR_BASE_PATH,
             'installed_plugins': self.installed_plugins,

--- a/djangocms_text_ckeditor/widgets.py
+++ b/djangocms_text_ckeditor/widgets.py
@@ -67,14 +67,13 @@ class TextEditorWidget(Textarea):
         # value or fallback to HTMLField
         else:
             configuration['toolbar'] = configuration.get('toolbar', 'HTMLField')
-        settings = json.dumps(configuration, cls=DjangoJSONEncoder)
         context = {
             'ckeditor_class': self.ckeditor_class,
             'ckeditor_selector': ckeditor_selector,
             'ckeditor_function': ckeditor_selector.replace('-', '_'),
             'name': name,
             'language': language,
-            'settings': language.join(settings.split("{{ language }}")),
+            'settings': language.join(json.dumps(configuration, cls=DjangoJSONEncoder).split("{{ language }}")),
             'STATIC_URL': settings.STATIC_URL,
             'CKEDITOR_BASEPATH': text_settings.TEXT_CKEDITOR_BASE_PATH,
             'installed_plugins': self.installed_plugins,

--- a/djangocms_text_ckeditor/widgets.py
+++ b/djangocms_text_ckeditor/widgets.py
@@ -67,13 +67,14 @@ class TextEditorWidget(Textarea):
         # value or fallback to HTMLField
         else:
             configuration['toolbar'] = configuration.get('toolbar', 'HTMLField')
+        settings = json.dumps(configuration, cls=DjangoJSONEncoder)
         context = {
             'ckeditor_class': self.ckeditor_class,
             'ckeditor_selector': ckeditor_selector,
             'ckeditor_function': ckeditor_selector.replace('-', '_'),
             'name': name,
             'language': language,
-            'settings': language.join(json.dumps(configuration, cls=DjangoJSONEncoder).split("{{ language }}")),
+            'settings': language.join(settings.split("{{ language }}")),
             'STATIC_URL': settings.STATIC_URL,
             'CKEDITOR_BASEPATH': text_settings.TEXT_CKEDITOR_BASE_PATH,
             'installed_plugins': self.installed_plugins,


### PR DESCRIPTION
While searching for a solution to solve #408 , I came across this litte bug:

Just by invoking ``json.dumps(python_dict)`` it is impossible to serialize lazy objects.
Instead, one should always use the ``DjangoJSONEncoder ``, which is explicitly dedicated for that purpose.