### PR TITLE
Fix #418: Multiple HTMLFields can't have different configurations

### DIFF
--- a/djangocms_text_ckeditor/templates/cms/plugins/widgets/ckeditor.html
+++ b/djangocms_text_ckeditor/templates/cms/plugins/widgets/ckeditor.html
@@ -15,8 +15,8 @@
 // CMS.$ will be passed for $
 $(document).ready(function () {
     function initCMSCKEditor{{ ckeditor_function }}() {
-        if ($('.CMS_CKEditor:visible').length > 0) {
-            $('.CMS_CKEditor:visible').each(function() {
+        if ($('#{{ ckeditor_selector }}:visible').length > 0) {
+            $('#{{ ckeditor_selector }}:visible').each(function() {
                 var editor = $(this);
 
                 if (editor.data('isCKEditorInitialized')) {


### PR DESCRIPTION
Fix to the the following open issue:

[Multiple HTMLFields can't have different configurations #418 ](https://github.com/divio/djangocms-text-ckeditor/issues/418)