### PR TITLE
Fixed a bug where plugin would be incorrectly deleted

### DIFF
--- a/djangocms_text_ckeditor/tests/test_plugin.py
+++ b/djangocms_text_ckeditor/tests/test_plugin.py
@@ -721,6 +721,15 @@ class PluginActionsTestCase(BaseTestCase):
             expected = sorted([plugins[4].pk, plugins[5].pk])
             self.assertEqual(idlist, expected)
 
+    def test_plugin_tags_to_id_list(self):
+        pairs = (
+            ('<cms-plugin id="1"></cms-plugin><cms-plugin id="2"></cms-plugin>', [1, 2]),
+            ('<cms-plugin alt="<h1>markup</h1>" id="1"></cms-plugin><cms-plugin id="1"></cms-plugin>', [1, 1]),
+        )
+
+        for markup, expected in pairs:
+            self.assertEqual(plugin_tags_to_id_list(markup), expected)
+
     def test_text_plugin_xss(self):
         page = create_page('test page', 'page.html', u'en')
         placeholder = page.placeholders.get(slot='content')

--- a/djangocms_text_ckeditor/utils.py
+++ b/djangocms_text_ckeditor/utils.py
@@ -13,7 +13,7 @@ from django.utils.decorators import available_attrs
 from django.utils.functional import LazyObject
 
 
-OBJ_ADMIN_RE_PATTERN = r'<cms-plugin [^>]*\bid="(?P<pk>\d+)"[^>]*/?>.*?</cms-plugin>'
+OBJ_ADMIN_RE_PATTERN = r'<cms-plugin .*?\bid="(?P<pk>\d+)".*?>.*?</cms-plugin>'
 OBJ_ADMIN_RE = re.compile(OBJ_ADMIN_RE_PATTERN, flags=re.DOTALL)
 
 


### PR DESCRIPTION
Child plugins of TextPlugin can contain html markup in their __str__
representation, which wasn't handled properly by the regex in
`plugin_tags_to_id_list`