### PR TITLE
Used assertXMLEqual() to improve robustness of PluginActionsTestCase.test_user_cant_edit_child_plugins_directly.

### DIFF
--- a/djangocms_text_ckeditor/tests/test_plugin.py
+++ b/djangocms_text_ckeditor/tests/test_plugin.py
@@ -445,7 +445,7 @@ class PluginActionsTestCase(BaseTestCase):
             text_plugin.refresh_from_db()
 
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(text_plugin.body, expected_text)
+            self.assertXMLEqual(text_plugin.body, expected_text)
 
     def test_render_child_plugin_endpoint(self):
         simple_page = create_page('test page', 'page.html', u'en')


### PR DESCRIPTION
See failed build: https://travis-ci.org/divio/djangocms-text-ckeditor/jobs/284735340.