### PR TITLE
Remove HTMLField configuration from aldryn_config

### DIFF
--- a/aldryn_config.py
+++ b/aldryn_config.py
@@ -27,22 +27,6 @@ class Form(forms.BaseForm):
             'language': '{{ language }}',
             'toolbar': 'CMS',
             'skin': 'moono-lisa',
-            'extraPlugins': 'cmsplugins',
-            'toolbar_HTMLField': [
-                ['Undo', 'Redo'],
-                ['cmsplugins', '-', 'ShowBlocks'],
-                ['Format', 'Styles'],
-                ['TextColor', 'BGColor', '-', 'PasteText', 'PasteFromWord'],
-                ['Maximize', ''],
-                '/',
-                ['Bold', 'Italic', 'Underline', '-', 'Subscript', 'Superscript', '-', 'RemoveFormat'],
-                ['JustifyLeft', 'JustifyCenter', 'JustifyRight'],
-                ['HorizontalRule'],
-                ['Link', 'Unlink'],
-                ['NumberedList', 'BulletedList', '-', 'Outdent', 'Indent', '-', 'Table'],
-                ['Source'],
-                ['Link', 'Unlink', 'Anchor'],
-            ],
         }
 
         # This could fail if aldryn-django-cms has not been configured yet.


### PR DESCRIPTION
The configuration was outdated. Default one should be taken from
javascript. Most notably - `cmsplugins` should not be there, since it's
not possible to add cms plugins to HTMLField