### PR TITLE
Make widget media lazy

### DIFF
--- a/djangocms_text_ckeditor/widgets.py
+++ b/djangocms_text_ckeditor/widgets.py
@@ -2,9 +2,9 @@
 import json
 from copy import deepcopy
 
+from django import forms
 from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
-from django.forms import Textarea
 from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
 from django.utils.translation.trans_real import get_language
@@ -18,7 +18,7 @@ from . import settings as text_settings
 PATH_TO_JS = 'djangocms_text_ckeditor/js/dist/bundle-45a646fecc.cms.ckeditor.min.js'
 
 
-class TextEditorWidget(Textarea):
+class TextEditorWidget(forms.Textarea):
     def __init__(self, attrs=None, installed_plugins=None, pk=None,
                  placeholder=None, plugin_language=None, configuration=None,
                  cancel_url=None, render_plugin_url=None, action_token=None,

--- a/djangocms_text_ckeditor/widgets.py
+++ b/djangocms_text_ckeditor/widgets.py
@@ -19,17 +19,6 @@ PATH_TO_JS = 'djangocms_text_ckeditor/js/dist/bundle-45a646fecc.cms.ckeditor.min
 
 
 class TextEditorWidget(Textarea):
-    class Media:
-        js = (
-            static_with_version('cms/js/dist/bundle.admin.base.min.js'),
-            static(PATH_TO_JS),
-        )
-        css = {
-            'all': {
-                'djangocms_text_ckeditor/css/cms.ckeditor.css'
-            }
-        }
-
     def __init__(self, attrs=None, installed_plugins=None, pk=None,
                  placeholder=None, plugin_language=None, configuration=None,
                  cancel_url=None, render_plugin_url=None, action_token=None,
@@ -66,6 +55,20 @@ class TextEditorWidget(Textarea):
         self.render_plugin_url = render_plugin_url
         self.action_token = action_token
         self.delete_on_cancel = delete_on_cancel
+
+   @property
+    def media(self):
+        return forms.Media(
+            css={
+                'all': {
+                    'djangocms_text_ckeditor/css/cms.ckeditor.css'
+                },
+            },
+            js=(
+                static_with_version('cms/js/dist/bundle.admin.base.min.js'),
+                static(PATH_TO_JS),
+            )
+        )
 
     def render_textarea(self, name, value, attrs=None):
         return super(TextEditorWidget, self).render(name, value, attrs)

--- a/djangocms_text_ckeditor/widgets.py
+++ b/djangocms_text_ckeditor/widgets.py
@@ -56,7 +56,7 @@ class TextEditorWidget(Textarea):
         self.action_token = action_token
         self.delete_on_cancel = delete_on_cancel
 
-   @property
+    @property
     def media(self):
         return forms.Media(
             css={

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,6 +2,7 @@ djangocms-helper>=0.9.2,<0.10
 django-filer>=1.3.0
 djangocms-picture>=2.0.6
 djangocms-link>=2.1.2
+django-polymorphic<2.0 # >= 2.0 doesn't support Django 1.8
 
 Pillow
 html5lib>=0.999999


### PR DESCRIPTION
Prevent static file resolution on import, fixes #476.

I put the media property above `__init__`, makes static files clear early, but may not be the preferred style.