### PR TITLE
Added spaceless tag around render_plugin_preview

### DIFF
--- a/djangocms_text_ckeditor/templates/cms/plugins/render_plugin_preview.html
+++ b/djangocms_text_ckeditor/templates/cms/plugins/render_plugin_preview.html
@@ -1,1 +1,1 @@
-{% load djangocms_text_ckeditor_tags %}{% render_plugin_preview plugin %}
+{% spaceless %}{% load djangocms_text_ckeditor_tags %}{% render_plugin_preview plugin %}{% endspaceless %}


### PR DESCRIPTION
This is to avoid having a new line (user rendered as a space) just after the plugin.