### PR TITLE
Bumped version to 3.8.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 =========
 
 
-3.8.0 (unreleased)
+3.8.0 (2019-05-23)
 ==================
 
 * Added support for Django 2.2 and django CMS 3.7

--- a/djangocms_text_ckeditor/__init__.py
+++ b/djangocms_text_ckeditor/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
-__version__ = '3.7.0'
+__version__ = '3.8.0'
 
 default_app_config = 'djangocms_text_ckeditor.apps.TextCkeditorConfig'


### PR DESCRIPTION
* Added support for Django 2.2 and django CMS 3.7
* Removed support for Django 2.0
* Extended test matrix
* Added isort and adapted imports
* Adapted code base to align with other supported addons
* Updated translations