### PR TITLE
DjangoCMS CKEditor plugin creates incorrect urls when static files are hosted on a CDN

### DIFF
--- a/djangocms_text_ckeditor/settings.py
+++ b/djangocms_text_ckeditor/settings.py
@@ -27,6 +27,8 @@ TEXT_ADDITIONAL_ATTRIBUTES = getattr(settings, 'TEXT_ADDITIONAL_ATTRIBUTES', ())
 TEXT_ADDITIONAL_PROTOCOLS = getattr(settings, 'TEXT_ADDITIONAL_PROTOCOLS', ())
 TEXT_CKEDITOR_CONFIGURATION = getattr(settings, 'TEXT_CKEDITOR_CONFIGURATION', None)
 TEXT_HTML_SANITIZE = getattr(settings, 'TEXT_HTML_SANITIZE', True)
+# This would make sure correct urls are created for
+# when static files are hosted on django and on a CDN. Old code was working fine for Django but not for CDNs.
 TEXT_CKEDITOR_BASE_PATH = getattr(
     settings, 'TEXT_CKEDITOR_BASE_PATH', static('djangocms_text_ckeditor/ckeditor/')
 )

--- a/djangocms_text_ckeditor/settings.py
+++ b/djangocms_text_ckeditor/settings.py
@@ -1,11 +1,7 @@
 # -*- coding: utf-8 -*-
-try:
-    from urllib.parse import urljoin
-except ImportError:
-    # Python 2
-    from urlparse import urljoin
 
 from django.conf import settings
+from django.templatetags.static import static
 from django.utils.translation import ugettext_lazy as _
 
 
@@ -32,7 +28,7 @@ TEXT_ADDITIONAL_PROTOCOLS = getattr(settings, 'TEXT_ADDITIONAL_PROTOCOLS', ())
 TEXT_CKEDITOR_CONFIGURATION = getattr(settings, 'TEXT_CKEDITOR_CONFIGURATION', None)
 TEXT_HTML_SANITIZE = getattr(settings, 'TEXT_HTML_SANITIZE', True)
 TEXT_CKEDITOR_BASE_PATH = getattr(
-    settings, 'TEXT_CKEDITOR_BASE_PATH', urljoin(settings.STATIC_URL, 'djangocms_text_ckeditor/ckeditor/')
+    settings, 'TEXT_CKEDITOR_BASE_PATH', static('djangocms_text_ckeditor/ckeditor/')
 )
 TEXT_AUTO_HYPHENATE = getattr(settings, 'TEXT_AUTO_HYPHENATE', True)
 TEXT_PLUGIN_NAME = getattr(settings, 'TEXT_PLUGIN_NAME', _("Text"))


### PR DESCRIPTION
When the CKEditor plugin window opens, a 404 error is thrown because the current code uses `urljoin` to create the path to DjangoCMS CKEditor's static files. But if the files are hosted on a CDN, `netloc` parameter of `urljoin` will be that of the localhost or the domain but not of the CDN.

The easiest fix is to simply use the `static() `function from` django.templatetags.static` instead of `urljoin` to create all static urls.

Example of files that throw 404:

1. djangocms_text_ckeditor/ckeditor/config.js
2. djangocms_text_ckeditor/ckeditor/skins/moono-lisa/editor_gecko.css
3. djangocms_text_ckeditor/ckeditor/lang/fr.js

The other side benefit is that this also gets rid of `python2/3 `compatibility and variance of `urljoin`