### PR TITLE
Port remaining Django 1.11, 2.0, 2.1 and 2.2 changes from master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,35 @@ language: python
 
 sudo: false
 
-python:
-  - 3.5
-
-env:
-  matrix:
-  - DJANGO='dj111' CMS='cms40' FE=1
-  - DJANGO='dj20' CMS='cms40' FE=1
-  - DJANGO='dj22' CMS='cms40' FE=1
+matrix:
+  include:
+    - python: 3.5
+      env: TOX_ENV='flake8'
+    - python: 3.5
+      env: TOX_ENV='isort'
+      # Django 1.11
+    - python: 3.5
+      env: DJANGO='dj111' CMS='cms40' FE=1
+    # Django 2.1
+    - python: 3.6
+      env: DJANGO='dj21' CMS='cms40' FE=1
+    # Django 2.2
+    - python: 3.6
+      env: DJANGO='dj22' CMS='cms40' FE=1
+    - python: 3.7
+      env: DJANGO='dj22' CMS='cms40' FE=1
+      dist: xenial
+      sudo: true
+    - python: 3.8
+      env: DJANGO='dj22' CMS='cms40'
 
 before_script:
+  - pip install coverage isort tox
+  - "if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then export PY_VER=py35; fi"
+  - "if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then export PY_VER=py36; fi"
+  - "if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then export PY_VER=py37; fi"
+  - "if [[ $TRAVIS_PYTHON_VERSION == '3.8' ]]; then export PY_VER=py38; fi"
+  - "if [[ ${DJANGO}z != 'z' ]]; then export TOX_ENV=$PY_VER-$DJANGO-$CMS; fi"
   - if [ "$FE" == 1 ]; then nvm install 8 && nvm use 8; fi
   - if [ "$FE" == 1 ]; then npm config set spin false; fi
   - if [ "$FE" == 1 ]; then npm install -g npm; fi
@@ -21,13 +40,16 @@ before_script:
   - if [ "$FE" == 1 ]; then npm install -g codeclimate-test-reporter; fi
   - if [ "$FE" == 1 ]; then npm ci; fi
 
-# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
   - pip install -U tox>=1.8 coveralls
-  - "if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then export PYVER=py35; fi"
+  - "if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then export PY_VER=py35; fi"
+  - "if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then export PY_VER=py36; fi"
+  - "if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then export PY_VER=py37; fi"
+  - "if [[ ${DJANGO}z != 'z' ]]; then export TOX_ENV=$PY_VER-$DJANGO-$CMS; fi"
   - "if [[ $FE == 1 ]]; then export FE_STR='-fe'; fi"
 
-# command to run tests, e.g. python setup.py test
-script: COMMAND='coverage run' tox -e"$PYVER-$DJANGO-$CMS$FE_STR",pep8
+script:
+  - tox -e $TOX_ENV
 
-after_success: coveralls
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ matrix:
   include:
     - python: 3.5
       env: TOX_ENV='flake8'
-    - python: 3.5
-      env: TOX_ENV='isort'
+    #- python: 3.5
+    #  env: TOX_ENV='isort' FIXME: For isort to pass the following changes need to be ported to this support/4.0.x branch:
+    #                       https://github.com/divio/djangocms-text-ckeditor/commit/a6069096fdac80931fd328055d1d615d168c33df
       # Django 1.11
     - python: 3.5
       env: DJANGO='dj111' CMS='cms40' FE=1

--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,8 @@ Text Plugin for django-cms with CKEditor.
 
 The latest version of this package supports:
 
-* Django >= 1.8
-* django CMS >= 3.3
+* Django >= 1.11
+* django CMS >= 4.0
 
 .. WARNING::
    - For django CMS 3.4.x use ``djangocms-text-ckeditor`` >= 3.2.x (e.g.: version 3.2.1).
@@ -320,8 +320,8 @@ You can further `customize your plugin`_ as other plugins.
 Adding plugins to the "CMS Plugins" dropdown
 --------------------------------------------
 
-If you have created a plugin that you want to use within Text plugins you can make them appear in the dropdown by 
-making them `text_enabled`. This means that you assign the property ``text_enabled`` of a plugin to ``True``, 
+If you have created a plugin that you want to use within Text plugins you can make them appear in the dropdown by
+making them `text_enabled`. This means that you assign the property ``text_enabled`` of a plugin to ``True``,
 the default value is `False`. Here is a very simple implementation::
 
     class MyTextPlugin(TextPlugin):
@@ -329,8 +329,8 @@ the default value is `False`. Here is a very simple implementation::
         model = MyTextModel
         text_enabled = True
 
-When the plugin is picked up, it will be available in the *CMS Plugins* dropdown, which you can find in the editor. 
-This makes it very easy for users to insert special content in a user-friendly Text block, which they are familiair with. 
+When the plugin is picked up, it will be available in the *CMS Plugins* dropdown, which you can find in the editor.
+This makes it very easy for users to insert special content in a user-friendly Text block, which they are familiair with.
 
 The plugin will even be previewed in the text editor. **Pro-tip**: make sure your plugin provides its own `icon_alt` method.
 That way, if you have many `text_enabled`-plugins, it can display a hint about it. For example, if you created a plugin which displays prices of configurable product, it can display a tooltip with the name of that product.

--- a/djangocms_text_ckeditor/cms_plugins.py
+++ b/djangocms_text_ckeditor/cms_plugins.py
@@ -3,20 +3,10 @@ from distutils.version import LooseVersion
 import json
 import re
 
-import cms
-from cms.models import CMSPlugin
-from cms.plugin_base import CMSPluginBase
-from cms.plugin_pool import plugin_pool
-from cms.utils.placeholder import get_toolbar_plugin_struct
-from cms.utils.urlutils import admin_reverse
 from django.conf.urls import url
 from django.contrib.admin.utils import unquote
 from django.core import signing
 from django.core.exceptions import PermissionDenied, ValidationError
-try:
-    from django.core.urlresolvers import reverse
-except ImportError:
-    from django.urls import reverse
 from django.db import transaction
 from django.forms.fields import CharField
 from django.http import (
@@ -24,6 +14,7 @@ from django.http import (
 )
 from django.shortcuts import get_object_or_404
 from django.template import RequestContext
+from django.urls import reverse
 from django.utils import six
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_text
@@ -31,18 +22,25 @@ from django.utils.translation import ugettext
 from django.views.decorators.clickjacking import xframe_options_sameorigin
 from django.views.decorators.http import require_POST
 
+import cms
+from cms.models import CMSPlugin
+from cms.plugin_base import CMSPluginBase
+from cms.plugin_pool import plugin_pool
+from cms.utils.placeholder import get_toolbar_plugin_struct
+from cms.utils.urlutils import admin_reverse
+
 from . import settings
 from .forms import ActionTokenValidationForm, DeleteOnCancelForm, RenderPluginForm, TextForm
 from .models import Text
 from .utils import (
     OBJ_ADMIN_WITH_CONTENT_RE_PATTERN,
+    _plugin_tags_to_html,
     plugin_tags_to_admin_html,
     plugin_tags_to_id_list,
     plugin_tags_to_user_html,
     random_comment_exempt,
     replace_plugin_tags,
     plugin_to_tag,
-    _plugin_tags_to_html,
 )
 from .widgets import TextEditorWidget
 
@@ -243,7 +241,7 @@ class TextPlugin(CMSPluginBase):
         # should we delete the text plugin when
         # the user cancels?
         delete_text_on_cancel = (
-            'delete-on-cancel' in request.GET and
+            'delete-on-cancel' in request.GET and  # noqa
             not plugin.get_plugin_instance()[0]
         )
 
@@ -408,7 +406,7 @@ class TextPlugin(CMSPluginBase):
         # The following is needed for permission checking
         plugin_class.opts = plugin_class.model._meta
 
-        if not (plugin_class.has_change_permission(request, obj=text_plugin) and
+        if not (plugin_class.has_change_permission(request, obj=text_plugin) and  # noqa
                 _user_can_change_placeholder(request, text_plugin.placeholder)):
             raise PermissionDenied
         return HttpResponse(form.render_plugin(request))
@@ -443,7 +441,7 @@ class TextPlugin(CMSPluginBase):
         # Check for add permissions because this view is meant
         # only for plugins created through the ckeditor
         # and the ckeditor plugin itself.
-        if not (plugin_class.has_add_permission(request) and
+        if not (plugin_class.has_add_permission(request) and  # noqa
                 _user_can_change_placeholder(request, text_plugin.placeholder)):
             raise PermissionDenied
         # Token is validated after checking permissions

--- a/djangocms_text_ckeditor/test_app/admin.py
+++ b/djangocms_text_ckeditor/test_app/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+
 from .models import Topping, Pizza
 
 
@@ -13,7 +14,9 @@ class PizzaAdmin(admin.ModelAdmin):
             'fields': ('description',),
         }),
         ('Advanced', {
-            'classes': ('collapse',),
+            # NOTE: Disabled because when PizzaAdmin uses a collapsed
+            # class then the order of javascript libs is incorrect.
+            # 'classes': ('collapse',),
             'fields': ('allergens',)
         }),
     )

--- a/djangocms_text_ckeditor/test_app/cms_plugins.py
+++ b/djangocms_text_ckeditor/test_app/cms_plugins.py
@@ -1,8 +1,9 @@
+from django.template import engines
+
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
-from django.template import engines
-from djangocms_text_ckeditor.cms_plugins import TextPlugin
 
+from djangocms_text_ckeditor.cms_plugins import TextPlugin
 from djangocms_text_ckeditor.test_app.models import DummyLink, DummySpacer
 
 

--- a/djangocms_text_ckeditor/tests/frontend/integration/smoke.js
+++ b/djangocms_text_ckeditor/tests/frontend/integration/smoke.js
@@ -125,11 +125,12 @@ casper.test.begin('CKEditor loads correctly in HTMLField', function (test) {
             this.click('input[type=submit]');
         })
         .waitForSelector('.success', function () {
-            test.assertSelectorHasText('.success', 'The pizza "Pizza object" was added successfully.', 'Pizza added');
+            test.assertSelectorHasText('.success', 'was added successfully.', 'Pizza added');
+            test.assertSelectorHasText('.success', 'Pizza object', 'Pizza added');
         })
         .thenOpen(globals.baseUrl + 'admin/test_app/pizza/')
         .waitForSelector('#result_list', function() {
-            this.clickLabel('Pizza object');
+            this.click(xPath('//*[contains(text(), \'Pizza object\')]'));
         })
         .waitForSelector('#pizza_form', function () {
             test.assertEval(function () {
@@ -148,7 +149,9 @@ casper.test.begin('CKEditor loads correctly in HTMLField', function (test) {
         });
 });
 
-// Fails because of casperjs javascript error that occurs after django 2.2.1
+// NOTE: Disabled because when PizzaAdmin uses a collapsed
+//       class then the order of javascript libs is incorrect.
+//       Fails because of casperjs javascript error that occurs after django 2.2.1
 // casper.test.begin('CKEditor loads correctly in collapsed fieldset', function (test) {
 //     casper
 //         .start(globals.baseUrl + 'admin/test_app/pizza/add')
@@ -243,11 +246,12 @@ casper.test.begin('CKEditor loads correctly in an inline', function (test) {
             this.click('input[type=submit]');
         })
         .waitForSelector('.success', function () {
-            test.assertSelectorHasText('.success', 'The pizza "Pizza object" was added successfully.', 'Pizza added');
+            test.assertSelectorHasText('.success', 'was added successfully.', 'Pizza added');
+            test.assertSelectorHasText('.success', 'Pizza object', 'Pizza added');
         })
         .thenOpen(globals.baseUrl + 'admin/test_app/pizza/')
         .then(function () {
-            this.clickLabel('Pizza object');
+            this.click(xPath('//*[contains(text(), \'Pizza object\')]'));
         })
         .waitForSelector('#pizza_form', function () {
             test.assertEval(function () {

--- a/djangocms_text_ckeditor/tests/test_field.py
+++ b/djangocms_text_ckeditor/tests/test_field.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
-
 from django.template import Context, Template
 from django.utils.safestring import SafeData
 
 from djangocms_helper.base_test import BaseTestCase
-
 from djangocms_text_ckeditor.fields import HTMLFormField
 from djangocms_text_ckeditor.test_app.forms import SimpleTextForm
 from djangocms_text_ckeditor.test_app.models import SimpleText

--- a/djangocms_text_ckeditor/tests/test_plugin.py
+++ b/djangocms_text_ckeditor/tests/test_plugin.py
@@ -4,10 +4,6 @@ import json
 import re
 import unittest
 
-from cms.api import add_plugin, create_page, create_title
-from cms.models import CMSPlugin, Page, PageContent
-from cms.utils.urlutils import admin_reverse
-import django
 from django.contrib import admin
 from django.contrib.auth import get_permission_codename
 from django.contrib.auth.models import Permission
@@ -15,6 +11,20 @@ from django.template import RequestContext
 from django.utils.encoding import force_text
 from django.utils.html import escape
 from django.utils.http import urlencode, urlunquote
+
+from cms.api import add_plugin, create_page, create_title
+from cms.models import CMSPlugin, Page
+from cms.utils.urlutils import admin_reverse
+
+from djangocms_text_ckeditor.cms_plugins import TextPlugin
+from djangocms_text_ckeditor.models import Text
+from djangocms_text_ckeditor.utils import (
+    _plugin_tags_to_html, _render_cms_plugin, plugin_tags_to_admin_html, plugin_tags_to_id_list,
+    plugin_to_tag,
+)
+
+from .base import BaseTestCase
+
 
 try:
     from djangocms_transfer.exporter import export_page
@@ -27,15 +37,6 @@ try:
     HAS_DJANGOCMS_TRANSLATIONS = True
 except ImportError:
     HAS_DJANGOCMS_TRANSLATIONS = False
-
-from djangocms_text_ckeditor.cms_plugins import TextPlugin
-from djangocms_text_ckeditor.models import Text
-from djangocms_text_ckeditor.utils import (
-    _plugin_tags_to_html, _render_cms_plugin, plugin_tags_to_admin_html, plugin_tags_to_id_list,
-    plugin_to_tag,
-)
-
-from .base import BaseTestCase
 
 
 class PluginActionsTestCase(BaseTestCase):
@@ -113,7 +114,7 @@ class PluginActionsTestCase(BaseTestCase):
         url = urlunquote(response.url)
         # Ideal case, this looks like:
         # /en/admin/cms/page/edit-plugin/1/
-        return re.findall('\d+', url)[0]
+        return re.findall('\d+', url)[0]  # noqa
 
     def test_add_and_edit_plugin(self):
         """

--- a/djangocms_text_ckeditor/tests/test_widget.py
+++ b/djangocms_text_ckeditor/tests/test_widget.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 from cms.api import add_plugin, create_page
 
-import django
-
 from djangocms_text_ckeditor import html, settings
 from djangocms_text_ckeditor.utils import plugin_to_tag
 

--- a/djangocms_text_ckeditor/utils.py
+++ b/djangocms_text_ckeditor/utils.py
@@ -12,7 +12,6 @@ from django.template.loader import render_to_string
 from django.utils.decorators import available_attrs
 from django.utils.functional import LazyObject
 
-
 OBJ_ADMIN_RE_PATTERN = r'<cms-plugin .*?\bid="(?P<pk>\d+)".*?>.*?</cms-plugin>'
 OBJ_ADMIN_WITH_CONTENT_RE_PATTERN = r'<cms-plugin .*?\bid="(?P<pk>\d+)".*?>(?P<content>.*?)</cms-plugin>'
 OBJ_ADMIN_RE = re.compile(OBJ_ADMIN_RE_PATTERN, flags=re.DOTALL)

--- a/djangocms_text_ckeditor/widgets.py
+++ b/djangocms_text_ckeditor/widgets.py
@@ -64,8 +64,6 @@ class TextEditorWidget(forms.Textarea):
                 'all': ('djangocms_text_ckeditor/css/cms.ckeditor.css',),
             },
             js=(
-                'admin/js/vendor/jquery/jquery.min.js',
-                'admin/js/jquery.init.js',
                 static_with_version('cms/js/dist/bundle.admin.base.min.js'),
                 static(PATH_TO_JS),
             )

--- a/djangocms_text_ckeditor/widgets.py
+++ b/djangocms_text_ckeditor/widgets.py
@@ -4,11 +4,11 @@ from copy import deepcopy
 
 from django import forms
 from django.conf import settings
+from django.contrib.admin.templatetags.admin_static import static
 from django.core.serializers.json import DjangoJSONEncoder
 from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
 from django.utils.translation.trans_real import get_language
-from django.contrib.admin.templatetags.admin_static import static
 
 from cms.utils.urlutils import static_with_version
 
@@ -69,10 +69,10 @@ class TextEditorWidget(forms.Textarea):
             )
         )
 
-    def render_textarea(self, name, value, attrs=None):
-        return super(TextEditorWidget, self).render(name, value, attrs)
+    def render_textarea(self, name, value, attrs=None, renderer=None):
+        return super(TextEditorWidget, self).render(name, value, attrs, renderer)
 
-    def render_additions(self, name, value, attrs=None):
+    def render_additions(self, name, value, attrs=None, renderer=None):
         # id attribute is always present when rendering a widget
         ckeditor_selector = attrs['id']
         language = get_language().split('-')[0]
@@ -105,10 +105,11 @@ class TextEditorWidget(forms.Textarea):
             'plugin_position': self.plugin_position,
             'placeholder': self.placeholder,
             'widget': self,
+            'renderer': renderer,
         }
         return mark_safe(render_to_string('cms/plugins/widgets/ckeditor.html', context))
 
-    def render(self, name, value, attrs=None, **kwargs):
+    def render(self, name, value, attrs=None, renderer=None):
         return (
-            self.render_textarea(name, value, attrs) + self.render_additions(name, value, attrs)
+            self.render_textarea(name, value, attrs) + self.render_additions(name, value, attrs, renderer=None)
         )

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from setuptools import setup
+
 from djangocms_text_ckeditor import __version__
 
 
 INSTALL_REQUIRES = [
-    'django-cms>=3.3.0',
+    'django-cms',
     'html5lib>=0.999999999',
     'Pillow',
 ]
@@ -21,15 +22,16 @@ CLASSIFIERS = [
     'Topic :: Communications',
     'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     'Topic :: Internet :: WWW/HTTP :: Dynamic Content :: Message Boards',
-    'Programming Language :: Python :: 2.6',
     'Programming Language :: Python :: 2.7',
-    'Programming Language :: Python :: 3.3',
-    'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
     'Framework :: Django',
-    'Framework :: Django :: 1.8',
-    'Framework :: Django :: 1.9',
-    'Framework :: Django :: 1.10',
     'Framework :: Django :: 1.11',
+    'Framework :: Django :: 2.0',
+    'Framework :: Django :: 2.1',
+    'Framework :: Django :: 2.2',
 ]
 
 setup(

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,14 +1,14 @@
-djangocms-helper>=1.1.0
-django-filer>=1.3.0
-djangocms-picture>=2.0.6
-djangocms-link>=2.1.2
+django-filer>=1.4.0
+djangocms-picture>=2.1.0
+djangocms-link>=2.2.1
+djangocms-helper>=1.1.0,<1.2.0
 
 Pillow
 html5lib>=0.999999999
 
-tox>=2.9.1
-coverage>=4.4.2
-flake8>=3.0.4
+tox
+coverage
+flake8
 
 # In order to run skipped tests uncomment the next lines:
 # -e git+ssh://git@github.com/divio/djangocms-transfer.git@master#egg=djangocms-transfer

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
-from tempfile import mkdtemp
 import os
 import sys
+from tempfile import mkdtemp
 
 port = 8000
 
 for arg in sys.argv:
     if arg.startswith('--port='):
         port = arg.split('=')[1]
+
 
 def gettext(s):
     return s
@@ -18,13 +19,7 @@ class DisableMigrations(dict):
         return True
 
     def __getitem__(self, item):
-        from distutils.version import LooseVersion
-        import django
-        DJANGO_1_9 = LooseVersion(django.get_version()) < LooseVersion('1.10')
-        if DJANGO_1_9:
-            return 'notmigrations'
-        else:
-            return None
+        return None
 
 
 HELPER_SETTINGS = {
@@ -115,13 +110,16 @@ HELPER_SETTINGS = {
 
 HELPER_SETTINGS['MIGRATION_MODULES'] = DisableMigrations()
 
+
 def _helper_patch(*args, **kwargs):
     from django.core.management import call_command
     call_command('migrate', run_syncdb=True)
 
+
 def test():
     from djangocms_helper import runner
     runner.cms('djangocms_text_ckeditor')
+
 
 def run():
     from djangocms_helper import runner
@@ -135,6 +133,7 @@ def run():
     # we use '.runner()', not '.cms()' nor '.run()' because it does not
     # add 'test' argument implicitly
     runner.runner([sys.argv[0], 'cms', '--cms', 'server', '--bind', '0.0.0.0', '--port', str(port)])
+
 
 if __name__ == "__main__":
     run()

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
     flake8
-    isort
+    # isort FIXME: For isort to pass the following changes need to be ported to this support/4.0.x branch:
+    #              https://github.com/divio/djangocms-text-ckeditor/commit/a6069096fdac80931fd328055d1d615d168c33df
     py{35,36,37,38}-dj{111,21,22}-cms40
 
 skip_missing_interpreters=True
@@ -23,6 +24,7 @@ exclude =
     requirements,
     tmp,
     *node_modules*
+    venv
 
 [isort]
 line_length = 79
@@ -42,7 +44,6 @@ deps =
     -r{toxinidir}/test_requirements.txt
 
     dj111: Django>=1.11,<2.0
-    dj111: django-formtools>=2.0,<2.1
     dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<3.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,30 +1,65 @@
 [tox]
 envlist =
-    py{35,36}-dj{111,20,22}-cms40
+    flake8
+    isort
+    py{35,36,37,38}-dj{111,21,22}-cms40
+
 skip_missing_interpreters=True
 
-[testenv]
-commands =
-    {env:COMMAND:python} setup.py test
-    fe: gulp tests:integration --clean
+[flake8]
+ignore = E251,E128,E501
+max-line-length = 119
+exclude =
+    *.egg-info,
+    .eggs,
+    .git,
+    .settings,
+    .tox,
+    build,
+    data,
+    dist,
+    docs,
+    *migrations*,
+    requirements,
+    tmp,
+    *node_modules*
 
+[isort]
+line_length = 79
+skip = manage.py, *migrations*, .tox, .eggs, data
+include_trailing_comma = true
+multi_line_output = 5
+not_skip = __init__.py
+lines_after_imports = 2
+default_section = THIRDPARTY
+sections = FUTURE, STDLIB, DJANGO, CMS, THIRDPARTY, FIRSTPARTY, LIB, LOCALFOLDER
+known_first_party = djangocms_text_ckeditor
+known_cms = cms, menus
+known_django = django
+
+[testenv]
 deps =
     -r{toxinidir}/test_requirements.txt
 
     dj111: Django>=1.11,<2.0
-    dj20: Django>=2.0,<2.1
+    dj111: django-formtools>=2.0,<2.1
+    dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<3.0
 
     cms40: https://github.com/divio/django-cms/archive/release/4.0.x.zip
 
-basepython =
-    py35: python3.5
-    py36: python3.6
+commands =
+    {envpython} --version
+    {env:COMMAND:coverage} erase
+    {env:COMMAND:coverage} run setup.py test
+    {env:COMMAND:coverage} report
+    fe: gulp tests:integration --clean
 
-[testenv:pep8]
+[testenv:flake8]
 deps = flake8
 commands = flake8
 
-[flake8]
-ignore = E251,E128,E501
-exclude = djangocms_text_ckeditor/tests/*,djangocms_text_ckeditor/migrations/*,test_settings.py,.tox/*,node_modules/*
+[testenv:isort]
+deps = isort
+commands = isort -c -rc -df djangocms_text_ckeditor
+skip_install = true


### PR DESCRIPTION
Implements the latest test configuration for Travis and Tox 

Removes recently added jquery js files that should not have been added in the plugin Media definition, this made the addon use the wrong jquery.

Ported any missed changes from master regarding Django 2.x support from:
-  Added support for Django versions 1.11/2.0/2.1 and dropped for 1.8/1.… https://github.com/divio/djangocms-text-ckeditor/commit/62a134ba4d399dd54d8df061b658c6b426722e55
- Added support for CMS 3.7 and Django 2.2 https://github.com/divio/djangocms-text-ckeditor/commit/61699a3d135f913dacedd3b0d2ff277085fc77f3