### PR TITLE
Handle cleaning ghosts for custom extended plugins

### DIFF
--- a/djangocms_text_ckeditor/cms_plugins.py
+++ b/djangocms_text_ckeditor/cms_plugins.py
@@ -293,7 +293,7 @@ class TextPlugin(CMSPluginBase):
                 super(TextPluginForm, self).__init__(*args, initial=initial, **kwargs)
         return TextPluginForm
 
-    def _clean_orphaned_ghost_plugins(self, language, placeholder, plugin_type="TextPlugin"):
+    def _clean_orphaned_ghost_plugins(self, language, placeholder):
         """
         If any "ghost" plugins are left behind by a failed cancellation
         the creation of a new plugin can be blocked by the fact that a new plugin is
@@ -303,7 +303,6 @@ class TextPlugin(CMSPluginBase):
         has_orphans = False
         placeholder_plugins = CMSPlugin.objects.filter(
             language=language,
-            plugin_type=plugin_type,
             placeholder=placeholder,
         )
 

--- a/tests/test_app/cms_plugins.py
+++ b/tests/test_app/cms_plugins.py
@@ -4,7 +4,7 @@ from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 
 from djangocms_text_ckeditor.cms_plugins import TextPlugin
-from tests.test_app.models import DummyLink, DummySpacer
+from tests.test_app.models import DummyLink, DummySpacer, ExtendedText
 
 
 @plugin_pool.register_plugin
@@ -25,6 +25,8 @@ class SekizaiPlugin(CMSPluginBase):
 @plugin_pool.register_plugin
 class ExtendedTextPlugin(TextPlugin):
     name = 'Extended'
+    model = ExtendedText
+    text_enabled = True
 
 
 @plugin_pool.register_plugin

--- a/tests/test_app/models.py
+++ b/tests/test_app/models.py
@@ -5,6 +5,7 @@ from django.utils.encoding import python_2_unicode_compatible
 from cms.models import CMSPlugin
 
 from djangocms_text_ckeditor.fields import HTMLField
+from djangocms_text_ckeditor.models import AbstractText
 
 
 class SimpleText(models.Model):
@@ -43,3 +44,10 @@ class Topping(models.Model):
     name = models.CharField(max_length=255)
     description = HTMLField()
     pizza = models.ForeignKey(Pizza, on_delete=models.CASCADE)
+
+
+class ExtendedText(AbstractText):
+    title = models.CharField(max_length=100)
+
+    class Meta:
+        abstract = False


### PR DESCRIPTION
An edge case has been discovered with a recent fix to the ckeditor for ghost plugins. When a custom text plugin instance is used the instance of the plugin is not of plugin type "TextPlugin".

Any text plugins that are not a standard plugin type of TextPlugin should also be able to handle orphaned ghost plugins.

Docs for the feature: https://github.com/divio/djangocms-text-ckeditor#extending-the-plugin