### PR TITLE
Prevent clean_html from sanitizing when TEXT_HTML_SANITIZE is False

### DIFF
--- a/djangocms_text_ckeditor/html.py
+++ b/djangocms_text_ckeditor/html.py
@@ -64,8 +64,12 @@ def clean_html(data, full=True, parser=DEFAULT_PARSER):
     else:
         dom_tree = parser.parseFragment(data)
     walker = treewalkers.getTreeWalker('dom')
-    kwargs = _filter_kwargs()
-    stream = TextSanitizer(walker(dom_tree), **kwargs)
+    stream = walker(dom_tree)
+
+    if settings.TEXT_HTML_SANITIZE:
+        kwargs = _filter_kwargs()
+        stream = TextSanitizer(stream, **kwargs)
+
     s = serializer.HTMLSerializer(
         omit_optional_tags=False,
         quote_attr_values='always',

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -82,7 +82,7 @@ class HtmlSanitizerAdditionalProtocolsTests(TestCase):
         old_TEXT_HTML_SANITIZE = settings.TEXT_HTML_SANITIZE
         settings.TEXT_HTML_SANITIZE = True
         parser = html._get_default_parser()
-        
+
         original = '<span test-attr="2">foo</span>'
         cleaned = html.clean_html(
             original,
@@ -98,7 +98,7 @@ class HtmlSanitizerAdditionalProtocolsTests(TestCase):
         old_TEXT_HTML_SANITIZE = settings.TEXT_HTML_SANITIZE
         settings.TEXT_HTML_SANITIZE = False
         parser = html._get_default_parser()
-        
+
         original = '<span test-attr="2">foo</span>'
         cleaned = html.clean_html(
             original,

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -77,3 +77,35 @@ class HtmlSanitizerAdditionalProtocolsTests(TestCase):
             parser=parser,
         )
         self.assertEqual('<source src="rtmp://testurl.com/">', text)
+
+    def test_clean_html_with_sanitize_enabled(self):
+        old_TEXT_HTML_SANITIZE = settings.TEXT_HTML_SANITIZE
+        settings.TEXT_HTML_SANITIZE = True
+        parser = html._get_default_parser()
+        
+        original = '<span test-attr="2">foo</span>'
+        cleaned = html.clean_html(
+            original,
+            full=False,
+            parser=parser,
+        )
+        try:
+            self.assertHTMLEqual('<span>foo</span>', cleaned)
+        finally:
+            settings.TEXT_HTML_SANITIZE = old_TEXT_HTML_SANITIZE
+
+    def test_clean_html_with_sanitize_disabled(self):
+        old_TEXT_HTML_SANITIZE = settings.TEXT_HTML_SANITIZE
+        settings.TEXT_HTML_SANITIZE = False
+        parser = html._get_default_parser()
+        
+        original = '<span test-attr="2">foo</span>'
+        cleaned = html.clean_html(
+            original,
+            full=False,
+            parser=parser,
+        )
+        try:
+            self.assertHTMLEqual(original, cleaned)
+        finally:
+            settings.TEXT_HTML_SANITIZE = old_TEXT_HTML_SANITIZE


### PR DESCRIPTION
It should be possible to disable sanitization by setting ``settings.TEXT_HTML_SANITIZER=False``, but in PR #482 the ``clean_html`` function started using ``TextSanitizer`` without first checking the setting.

Because ``models.AbstractText.save()`` calls ``clean_html``, no plugin can be saved without its HTML being sanitized.

This commit wraps the changes from #482 in a flag check, otherwise uses does not sanitize before serializing, as it did before that PR.

Tests are included for both conditions; ``True`` passes before the fix but ``False`` fails. Both pass after the fix.