### PR TITLE
Bumped version to 4.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,8 @@
 Changelog
 =========
 
-4.0.0 (unreleased)
+
+4.0.0 (2020-09-15)
 ==================
 
 * Added support for Django 3.1
@@ -11,6 +12,7 @@ Changelog
 * Ensure that correct urls are generated when static files are hosted on a CDN
 * Allow to style WYSIWYG content based on parent plugins, by adding
 ``CMSPluginBase.child_ckeditor_body_css_class`` to a parent (#520)
+* Upgrade to CKeditor version to 4.14.1
 
 
 3.10.0 (2020-08-04)

--- a/djangocms_text_ckeditor/__init__.py
+++ b/djangocms_text_ckeditor/__init__.py
@@ -16,6 +16,6 @@ Release logic:
 10. python setup.py sdist
 11. twine upload dist/djangocms-text-ckeditor-{new_version_number}.tar.gz
 """
-__version__ = '3.10.0'
+__version__ = '4.0.0'
 
 default_app_config = 'djangocms_text_ckeditor.apps.TextCkeditorConfig'


### PR DESCRIPTION
* Added support for Django 3.1
* Dropped support for Python 2.7 and Python 3.4
* Dropped support for Django < 2.2
* Ensure that correct urls are generated when static files are hosted on a CDN
* Allow to style WYSIWYG content based on parent plugins, by adding
``CMSPluginBase.child_ckeditor_body_css_class`` to a parent (#520)
* Upgrade to CKeditor version to 4.14.1